### PR TITLE
Allow for class aliases to be specified in plugin/module class loader

### DIFF
--- a/src/Support/ClassLoader.php
+++ b/src/Support/ClassLoader.php
@@ -240,7 +240,7 @@ class ClassLoader
      * Gets an alias for a class, if available.
      *
      * @param string $class
-     * @return void
+     * @return string|null
      */
     protected function getAlias($class)
     {

--- a/src/Support/ClassLoader.php
+++ b/src/Support/ClassLoader.php
@@ -62,6 +62,13 @@ class ClassLoader
     protected $registered = false;
 
     /**
+     * Class alias array.
+     *
+     * @var array
+     */
+    protected $aliases = [];
+
+    /**
      * Create a new package manifest instance.
      *
      * @param  \Winter\Storm\Filesystem\Filesystem  $files
@@ -104,6 +111,10 @@ class ClassLoader
                 $this->includeClass($class, $path);
                 return true;
             }
+        }
+
+        if (!is_null($alias = $this->getAlias($class))) {
+            return class_alias($alias, $class);
         }
     }
 
@@ -208,12 +219,43 @@ class ClassLoader
     }
 
     /**
+     * Adds alias to the class loader.
+     *
+     * Aliases are first-come, first-served. If a real class already exists with the same name as an alias, the real
+     * class is used over the alias.
+     *
+     * @param array $aliases
+     * @return void
+     */
+    public function addAliases(array $aliases)
+    {
+        foreach ($aliases as $original => $alias) {
+            if (!array_key_exists(strtolower($alias), $this->aliases)) {
+                $this->aliases[strtolower($alias)] = $original;
+            }
+        }
+    }
+
+    /**
+     * Gets an alias for a class, if available.
+     *
+     * @param string $class
+     * @return void
+     */
+    protected function getAlias($class)
+    {
+        return array_key_exists(strtolower($class), $this->aliases)
+            ? $this->aliases[strtolower($class)]
+            : null;
+    }
+
+    /**
      * Get the normal file name for a class.
      *
      * @param  string  $class
      * @return string
      */
-    protected function normalizeClass($class)
+    protected static function normalizeClass($class)
     {
         /*
          * Strip first slash

--- a/tests/Support/ClassLoaderTest.php
+++ b/tests/Support/ClassLoaderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Winter\Storm\Filesystem\Filesystem;
+use Winter\Storm\Support\ClassLoader;
+
+class ClassLoaderTest extends TestCase
+{
+    /** @var ClassLoader */
+    protected $classLoader;
+
+    public function setUp(): void
+    {
+        $this->classLoader = new ClassLoader(
+            new Filesystem(),
+            dirname(__DIR__) . '/fixtures/classes',
+            dirname(__DIR__) . '/fixtures/classes/classes.php'
+        );
+
+        $this->classLoader->register();
+
+        $this->classLoader->addDirectories([
+            'plugins'
+        ]);
+    }
+
+    public function testClassesExist()
+    {
+        // Classes should be available from the class loader
+        $this->assertTrue(class_exists('Winter\Plugin\Classes\TestClass'));
+        $this->assertTrue(class_exists('Winter\Plugin\Models\TestModel'));
+
+        // Classes should not be available from the class loader (missing classes)
+        $this->assertFalse(class_exists('Winter\Plugin\Classes\MissingClass'));
+        $this->assertFalse(class_exists('Winter\Plugin\Widgets\MissingWidget'));
+
+        // Class should not be available from the class loader (misnamed namespace)
+        $this->assertFalse(class_exists('Winter\Plugin\Controllers\TestController'));
+    }
+
+    public function testAliases()
+    {
+        // Alias missing classes
+        $this->classLoader->addAliases([
+            'Winter\Plugin\Classes\TestClass' => 'OldOrg\Plugin\Classes\TestClass',
+            'Winter\Plugin\Models\TestModel' => 'OldOrg\Plugin\Models\TestModel',
+        ]);
+
+        $this->assertTrue(class_exists('OldOrg\Plugin\Classes\TestClass'));
+        $this->assertTrue(class_exists('OldOrg\Plugin\Models\TestModel'));
+
+        $instance = new OldOrg\Plugin\Classes\TestClass;
+        $this->assertInstanceOf('Winter\Plugin\Classes\TestClass', $instance);
+
+        // Alias a class that exists - the original should still be used
+        $this->classLoader->addAliases([
+            'NewOrg\Plugin\Classes\TestClass' => 'Winter\Plugin\Classes\TestClass',
+        ]);
+
+        $instance = new Winter\Plugin\Classes\TestClass;
+        $this->assertInstanceOf('Winter\Plugin\Classes\TestClass', $instance);
+        $this->assertFalse(class_exists('NewOrg\Plugin\Classes\TestClass'));
+    }
+}

--- a/tests/fixtures/classes/plugins/winter/plugin/classes/TestClass.php
+++ b/tests/fixtures/classes/plugins/winter/plugin/classes/TestClass.php
@@ -1,0 +1,6 @@
+<?php namespace Winter\Plugin\Classes;
+
+class TestClass
+{
+
+}

--- a/tests/fixtures/classes/plugins/winter/plugin/controllers/TestController.php
+++ b/tests/fixtures/classes/plugins/winter/plugin/controllers/TestController.php
@@ -1,0 +1,6 @@
+<?php namespace Winter\Plugin\Controller;
+
+class TestController
+{
+    // This class' namespace is misspelt, to test missing classes
+}

--- a/tests/fixtures/classes/plugins/winter/plugin/models/TestModel.php
+++ b/tests/fixtures/classes/plugins/winter/plugin/models/TestModel.php
@@ -1,0 +1,6 @@
+<?php namespace Winter\Plugin\Models;
+
+class TestModel
+{
+
+}


### PR DESCRIPTION
This provides an `addAliases` method to the module/plugin class loader, allowing modules and plugins to provide aliases on initialization. This will assist with rebranding. Aliases are lazy-loaded, so that they won't be needed unless some functionality specifically requests them.

Usage:

```
use Winter\Storm\Support\ClassLoader;

app(ClassLoader::class)->addAliases([
    Winter\Test\Model\Test::class => OldLab\Test\Model\Test::class
]);
```