### PR TITLE
Change Auth Manager to not expose whether user exists or not on auth

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -240,15 +240,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
          */
         foreach ($hashedCredentials as $credential => $value) {
             if (!$user->checkHashValue($credential, $value)) {
-                // Incorrect password
-                if ($credential == 'password') {
-                    throw new AuthException(sprintf(
-                        'A user was found to match all plain text credentials however hashed credential "%s" did not match.',
-                        $credential
-                    ));
-                }
-
-                // User not found
+                // User doesn't exist or invalid password, should not expose if a user exists or not.
                 throw new AuthException('A user was not found with the given credentials.');
             }
         }


### PR DESCRIPTION
Applying logic of https://github.com/wintercms/winter/issues/32 to authentication check as well. We should not expose whether a user exists or not to the login form. Can either apply the check here or do a try/catch in the backend module.