### PR TITLE
[WIP] Translator afterResolve event

### DIFF
--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -127,7 +127,7 @@ class Translator extends TranslatorBase
             return $afterResolve;
         }
 
-        // If the line doesn't exist, we overrideswill return back the key which was requested as
+        // If the line doesn't exist, we will return back the key which was requested as
         // that will be quick to spot in the UI if language keys are wrong or missing
         // from the application's language files. Otherwise we can return the line.
         if (!isset($line)) {

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -59,10 +59,8 @@ class Translator extends TranslatorBase
          *     });
          *
          */
-        if (
-            isset($this->events)
-            && ($line = $this->events->fire('translator.beforeResolve', [$key, $replace, $locale], true))
-        ) {
+        if (isset($this->events) &&
+            ($line = $this->events->fire('translator.beforeResolve', [$key, $replace, $locale], true))) {
             return $line;
         }
 
@@ -120,10 +118,8 @@ class Translator extends TranslatorBase
          *     });
          *
          */
-        if (
-            isset($this->events)
-            && ($afterResolve = $this->events->fire('translator.afterResolve', [$key, $replace, $line, $locale], true))
-        ) {
+        if (isset($this->events) &&
+            ($afterResolve = $this->events->fire('translator.afterResolve', [$key, $replace, $line, $locale], true))) {
             return $afterResolve;
         }
 

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -59,8 +59,10 @@ class Translator extends TranslatorBase
          *     });
          *
          */
-        if (isset($this->events) &&
-            ($line = $this->events->fire('translator.beforeResolve', [$key, $replace, $locale], true))) {
+        if (
+            isset($this->events)
+            && ($line = $this->events->fire('translator.beforeResolve', [$key, $replace, $locale], true))
+        ) {
             return $line;
         }
 
@@ -105,7 +107,27 @@ class Translator extends TranslatorBase
             }
         }
 
-        // If the line doesn't exist, we will return back the key which was requested as
+        /**
+         * @event translator.afterResolve
+         * Fires after the translator resolves the requested language key
+         *
+         * Example usage (overrides the value returned for a specific language key):
+         *
+         *     Event::listen('translator.afterResolve', function ((string) $key, (array) $replace, (string|null) $line (string|null) $locale) {
+         *         if ($key === 'my.custom.key') {
+         *             return 'My overriding value';
+         *         }
+         *     });
+         *
+         */
+        if (
+            isset($this->events)
+            && ($afterResolve = $this->events->fire('translator.afterResolve', [$key, $replace, $line, $locale], true))
+        ) {
+            return $afterResolve;
+        }
+
+        // If the line doesn't exist, we overrideswill return back the key which was requested as
         // that will be quick to spot in the UI if language keys are wrong or missing
         // from the application's language files. Otherwise we can return the line.
         if (!isset($line)) {

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -63,14 +63,29 @@ class TranslatorTest extends TestCase
 
     public function testOverrideWithBeforeResolveEvent()
     {
-        $eventsDispatcher = $this->createMock(Dispatcher::class);
-        $eventsDispatcher
-            ->expects($this->exactly(2))
-            ->method('fire')
-            ->will($this->onConsecutiveCalls('Hello Override!', null));
+        $eventsDispatcher = new Dispatcher();
         $this->translator->setEventDispatcher($eventsDispatcher);
 
-        $this->assertEquals('Hello Override!', $this->translator->get('lang.test.hello_override'));
         $this->assertEquals('Hello Winter!', $this->translator->get('lang.test.hello_winter'));
+
+        $eventsDispatcher->listen('translator.beforeResolve', function () {
+            return 'Hello Override!';
+        });
+
+        $this->assertEquals('Hello Override!', $this->translator->get('lang.test.hello_override'));
+    }
+
+    public function testOverrideWithAfterResolveEvent()
+    {
+        $eventsDispatcher = new Dispatcher();
+        $this->translator->setEventDispatcher($eventsDispatcher);
+
+        $this->assertEquals('Hello Winter!', $this->translator->get('lang.test.hello_winter'));
+
+        $eventsDispatcher->listen('translator.afterResolve', function ($key, $replace, $line) {
+            return str_replace('Hello', 'Hi', $line);
+        });
+
+        $this->assertEquals('Hi Winter!', $this->translator->get('lang.test.hello_winter'));
     }
 }


### PR DESCRIPTION
Adds a new event that gets fired after an a translation has been resolved. Acts identically to beforeResolve except for it also passes the found line into the event, allowing for modifications to be made and fallback handlers for missing lines to be created.

Example:
```php
Event::listen(
    'translator.afterResolve',
    function (string $key, array $replace, ?string $line, ?string $locale) {
        // handle things 
        return $someVar;
    }
);
```