### PR TITLE
Add Symfony-3 compatible YAML processor for Yaml service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "linkorb/jsmin-php": "~1.0",
         "wikimedia/less.php": "~3.0",
         "scssphp/scssphp": "~1.0",
-        "symfony/yaml": "^3.4",
+        "symfony/yaml": "^4.4",
         "twig/twig": "~2.0",
         "league/csv": "~9.1",
         "nesbot/carbon": "^2.0",

--- a/src/Parse/ParseServiceProvider.php
+++ b/src/Parse/ParseServiceProvider.php
@@ -1,6 +1,7 @@
 <?php namespace Winter\Storm\Parse;
 
 use Illuminate\Support\ServiceProvider;
+use Winter\Storm\Parse\Processor\Symfony3Processor;
 
 class ParseServiceProvider extends ServiceProvider
 {
@@ -11,10 +12,23 @@ class ParseServiceProvider extends ServiceProvider
      */
     public $singletons = [
         'parse.markdown' => Markdown::class,
-        'parse.yaml' => Yaml::class,
         'parse.twig' => Twig::class,
         'parse.ini' => Ini::class,
     ];
+
+    /**
+     * Register the service provider.
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton('parse.yaml', function ($app) {
+            $yaml = new Yaml();
+            $yaml->setProcessor(new Symfony3Processor);
+
+            return $yaml;
+        });
+    }
 
     /**
      * Get the services provided by the provider.

--- a/src/Parse/Processor/Symfony3Processor.php
+++ b/src/Parse/Processor/Symfony3Processor.php
@@ -1,0 +1,39 @@
+<?php namespace Winter\Storm\Parse\Processor;
+
+use Winter\Storm\Parse\Processor\Contracts\YamlProcessor;
+
+/**
+ * Symfony/Yaml 3 processor.
+ *
+ * Fixes up YAML syntax that was valid in Symfony/Yaml 3 but no longer valid with Symfony/Yaml 4 due to the new YAML
+ * spec being adhered to.
+ *
+ * @author Winter CMS
+ */
+class Symfony3Processor implements YamlProcessor
+{
+    /**
+     * @inheritDoc
+     */
+    public function preprocess($text)
+    {
+        $lines = preg_split('/[\n\r]+/', $text, -1, PREG_SPLIT_NO_EMPTY);
+
+        foreach ($lines as &$line) {
+            // Surround array keys with quotes if not already
+            $line = preg_replace_callback('/^( *)([\'"]{0}[^\'"\n\r:]+[\'"]{0})\s*:/m', function ($matches) {
+                return $matches[1] . '"' . trim($matches[2]) . '":';
+            }, rtrim($line));
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process($parsed)
+    {
+        return $parsed;
+    }
+}

--- a/tests/Parse/YamlTest.php
+++ b/tests/Parse/YamlTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use Symfony\Component\Yaml\Exception\ParseException;
 use Winter\Storm\Parse\Processor\Contracts\YamlProcessor;
+use Winter\Storm\Parse\Processor\Symfony3Processor;
 use Winter\Storm\Parse\Yaml as YamlParser;
 
 class YamlTest extends TestCase
@@ -88,6 +90,63 @@ class YamlTest extends TestCase
                 'Test 3 Value 3',
             ],
         ], $yaml->test);
+    }
+
+    public function testSymfony3YamlFile()
+    {
+        // This YAML file should not be parseable by default
+        $this->expectException(ParseException::class);
+
+        $parser = new YamlParser;
+        $parser->parse(file_get_contents(dirname(__DIR__) . '/fixtures/yaml/symfony3.yaml'));
+    }
+
+    public function testSymfony3YamlFileWithProcessor()
+    {
+        $parser = new YamlParser;
+        $parser->setProcessor(new Symfony3Processor);
+        $yaml = $parser->parse(file_get_contents(dirname(__DIR__) . '/fixtures/yaml/symfony3.yaml'));
+
+        $this->assertEquals([
+            'form' => [
+                'fields' => [
+                    'testField' => [
+                        'type' => 'text',
+                        'label' => 'Test field',
+                    ],
+                    'testSelect' => [
+                        'type' => 'select',
+                        'label' => 'Do you rock the casbah?',
+                        'options' => [
+                            '0' => 'Nope',
+                            '1' => 'ROCK THE CASBAH!',
+                            '2' => 2,
+                        ],
+                    ],
+                    'testSelectTwo' => [
+                        'type' => 'select',
+                        'label' => 'Which decade of songs did you like?',
+                        'options' => [
+                            '1960s',
+                            '1970s',
+                            '1980s',
+                            '1990s',
+                            '2000s',
+                            '2010s',
+                            '2020s',
+                        ],
+                    ],
+                    'testBoolean' => [
+                        'type' => 'select',
+                        'label' => 'Is the sky blue?',
+                        'options' => [
+                            'true' => true,
+                            'false' => false,
+                        ],
+                    ],
+                ],
+            ],
+        ], $yaml);
     }
 }
 

--- a/tests/fixtures/yaml/symfony3.yaml
+++ b/tests/fixtures/yaml/symfony3.yaml
@@ -1,0 +1,31 @@
+# Test fixture to test a YAML file that was valid in Symfony/Yaml 3, but not v4.
+
+form:
+    "fields":
+        testField:
+            type: text
+            label: Test field
+        testSelect:
+            type: select
+            label: Do you rock the casbah?
+            options:
+                0: Nope
+                1: ROCK THE CASBAH!
+                2: 2
+        testSelectTwo:
+            type: select
+            label: "Which decade of songs did you like?"
+            options:
+                - 1960s
+                - 1970s
+                - "1980s"
+                - '1990s'
+                - 2000s
+                -    2010s
+                - 2020s
+        testBoolean:
+            type: select
+            label: Is the sky blue?
+            options:
+                true: true
+                false: false


### PR DESCRIPTION
Fixes up YAML processing globally by applying a Symfony 3 compatible YAML processor to the `parse.yaml` singleton. At the moment, this processor simply makes sure that all keys are strings by wrapping any unquoted keys with quotation marks, which should resolve the vast majority of issues.