### PR TITLE
[WIP] Config Aliases

### DIFF
--- a/src/Config/FileLoader.php
+++ b/src/Config/FileLoader.php
@@ -27,6 +27,13 @@ class FileLoader implements LoaderInterface
     protected $hints = [];
 
     /**
+     * All of the namespace aliases.
+     *
+     * @var array
+     */
+    protected $aliases = [];
+
+    /**
      * A cache of whether namespaces and groups exists.
      *
      * @var array
@@ -159,6 +166,13 @@ class FileLoader implements LoaderInterface
         if ($this->files->exists($path)) {
             $items = array_merge($items, $this->getRequire($path));
         }
+        // If package is has an alias and the package does not have a global config
+        elseif (isset($this->aliases[$package])) {
+            $path = $this->getPackagePath($this->aliases[$package], $group);
+            if ($this->files->exists($path)) {
+                $items = array_merge($items, $this->getRequire($path));
+            }
+        }
 
         // Once we have merged the regular package configuration we need to look for
         // an environment specific configuration file. If one exists, we will get
@@ -220,6 +234,18 @@ class FileLoader implements LoaderInterface
     public function addNamespace($namespace, $hint)
     {
         $this->hints[$namespace] = $hint;
+    }
+
+    /**
+     * Add a new namespace to the loader.
+     *
+     * @param  string  $namespace
+     * @param  string  $alias
+     * @return void
+     */
+    public function registerNamespaceAlias(string $namespace, string $alias)
+    {
+        $this->aliases[strtolower($namespace)] = strtolower($alias);
     }
 
     /**

--- a/src/Config/FileLoader.php
+++ b/src/Config/FileLoader.php
@@ -167,8 +167,8 @@ class FileLoader implements LoaderInterface
             $items = array_merge($items, $this->getRequire($path));
         }
         // If package is has an alias and the package does not have a global config
-        elseif (isset($this->aliases[$package])) {
-            $path = $this->getPackagePath($this->aliases[$package], $group);
+        elseif (($alias = array_search($package, $this->aliases)) && is_string($alias)) {
+            $path = $this->getPackagePath($alias, $group);
             if ($this->files->exists($path)) {
                 $items = array_merge($items, $this->getRequire($path));
             }
@@ -245,7 +245,7 @@ class FileLoader implements LoaderInterface
      */
     public function registerNamespaceAlias(string $namespace, string $alias)
     {
-        $this->aliases[strtolower($namespace)] = strtolower($alias);
+        $this->aliases[strtolower($alias)] = strtolower($namespace);
     }
 
     /**

--- a/src/Config/Repository.php
+++ b/src/Config/Repository.php
@@ -366,6 +366,9 @@ class Repository implements ArrayAccess, RepositoryContract
     /**
      * Add a alias to a namespace in the loader.
      *
+     *    // to allow for config('alias.demo::foo') to redirect to config('winter.demo::foo')
+     *    Config::registerNamespaceAlias('Winter.Demo', 'Alias.Demo');
+     *
      * @param  string  $namespace
      * @param  string  $alias
      * @return void
@@ -379,11 +382,14 @@ class Repository implements ArrayAccess, RepositoryContract
      * Register an alias in the loader that will add fallback to alias
      * support if a package config is not found
      *
+     *    // to allow for config('winter.demo::foo') to fallback to global 'alias.demo' config
+     *    Config::registerPackageFallback('Winter.Demo', 'Alias.Demo');
+     *
      * @param  string  $namespace
      * @param  string  $alias
      * @return void
      */
-    public function registerPackageAlias(string $namespace, string $alias)
+    public function registerPackageFallback(string $namespace, string $alias)
     {
         $this->loader->registerNamespaceAlias($namespace, $alias);
     }

--- a/src/Config/Repository.php
+++ b/src/Config/Repository.php
@@ -42,6 +42,13 @@ class Repository implements ArrayAccess, RepositoryContract
     protected $packages = [];
 
     /**
+     * All of the namespace aliases.
+     *
+     * @var array
+     */
+    protected $aliases = [];
+
+    /**
      * The after load callbacks for namespaces.
      *
      * @var array
@@ -258,6 +265,8 @@ class Repository implements ArrayAccess, RepositoryContract
     protected function parseNamespacedSegments($key)
     {
         list($namespace, $item) = explode('::', $key);
+        // load aliases namespace
+        $namespace = $this->aliases[$namespace] ?? $namespace;
 
         // If the namespace is registered as a package, we will just assume the group
         // is equal to the namespace since all packages cascade in this way having
@@ -352,6 +361,18 @@ class Repository implements ArrayAccess, RepositoryContract
     public function addNamespace($namespace, $hint)
     {
         $this->loader->addNamespace($namespace, $hint);
+    }
+
+    /**
+     * Add a new namespace to the loader.
+     *
+     * @param  string  $namespace
+     * @param  string  $alias
+     * @return void
+     */
+    public function registerNamespaceAlias(string $namespace, string $alias)
+    {
+        $this->aliases[strtolower($alias)] = strtolower($namespace);
     }
 
     /**

--- a/src/Config/Repository.php
+++ b/src/Config/Repository.php
@@ -364,7 +364,7 @@ class Repository implements ArrayAccess, RepositoryContract
     }
 
     /**
-     * Add a new namespace to the loader.
+     * Add a alias to a namespace in the loader.
      *
      * @param  string  $namespace
      * @param  string  $alias
@@ -373,6 +373,19 @@ class Repository implements ArrayAccess, RepositoryContract
     public function registerNamespaceAlias(string $namespace, string $alias)
     {
         $this->aliases[strtolower($alias)] = strtolower($namespace);
+    }
+
+    /**
+     * Register an alias in the loader that will add fallback to alias
+     * support if a package config is not found
+     *
+     * @param  string  $namespace
+     * @param  string  $alias
+     * @return void
+     */
+    public function registerPackageAlias(string $namespace, string $alias)
+    {
+        $this->loader->registerNamespaceAlias($namespace, $alias);
     }
 
     /**

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Winter\Storm\Config\Repository;
+use Winter\Storm\Config\FileLoader;
+use Illuminate\Filesystem\Filesystem;
+
+class ConfigTest extends TestCase
+{
+    protected $config;
+
+    public function setUp(): void
+    {
+        $fixture = __DIR__ . '/../fixtures/config';
+        $this->config = new Repository(new FileLoader(new Filesystem(), $fixture), 'test');
+        $this->config->package('winter.test', $fixture);
+    }
+
+    public function testGetFileConfig()
+    {
+        $this->assertEquals('mysql', $this->config->get('sample-config.default'));
+    }
+
+    public function testGetNamespaceConfig()
+    {
+        $this->assertEquals('bar', $this->config->get('winter.test::foo'));
+        $this->assertTrue($this->config->get('winter.test::bar'));
+    }
+
+    public function testGetAliasedNamespaceConfig()
+    {
+        $this->config->registerNamespaceAlias('winter.test', 'winter.alias');
+        $this->assertEquals('bar', $this->config->get('winter.alias::foo'));
+        $this->assertTrue($this->config->get('winter.alias::bar'));
+    }
+}

--- a/tests/fixtures/config/config.php
+++ b/tests/fixtures/config/config.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'foo' => 'bar',
+    'bar' => true
+];


### PR DESCRIPTION
Adds support for config aliasing.

```php
Config::package('winter.test', '/path/to/config');
Config::registerNamespaceAlias('winter.test', 'winter.alias');

Config::get('winter.test::foo'); // bar
Config::get('winter.alias::foo'); // bar
```