### PR TITLE
Support multiple where clauses in Unique validation rules

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -442,7 +442,7 @@ trait Validation
             $keyName,
             $whereColumn,
             $whereValue
-        ) = array_pad(explode(',', $definition), 6, null);
+        ) = array_pad(explode(',', $definition, 6), 6, null);
 
         $table = 'unique:' . $this->getConnectionName()  . '.' . $this->getTable();
         $column = $column ?: $fieldName;

--- a/tests/Database/Traits/ValidationTest.php
+++ b/tests/Database/Traits/ValidationTest.php
@@ -55,6 +55,21 @@ class ValidationTest extends TestCase
         $this->assertEquals([
             'email' => ['unique:mysql.users,email_address,20,id,account_id,1']
         ], $this->processValidationRules($rules));
+
+        /*
+         * Adding multiple additional where clauses
+         */
+        $rules = ['email' => 'unique:users,email_address,NULL,id,account_id,1,account_name,"Foo",user_id,3'];
+
+        $this->exists = true;
+        $this->assertEquals([
+            'email' => ['unique:mysql.users,email_address,20,id,account_id,1,account_name,"Foo",user_id,3']
+        ], $this->processValidationRules($rules));
+
+        $this->exists = false;
+        $this->assertEquals([
+            'email' => ['unique:mysql.users,email_address,20,id,account_id,1,account_name,"Foo",user_id,3']
+        ], $this->processValidationRules($rules));
     }
 
     protected function getConnectionName()


### PR DESCRIPTION
## Description

Winter is currently stripping any *where* clause after the first one from Unique validation rules. This PR aims to fix the problem.

## In Depth

The laravel Unique validation rule supports [multiple where clauses](https://github.com/laravel/framework/blob/9edd46fc6dcd550e4fd5d081bea37b0a43162165/src/Illuminate/Validation/Rules/DatabaseRule.php#L83). You can use it like so:
```php
Rule::unique('my_table')
    ->where('field_1', 'foo')
    ->where('field_2', 'bar')
```
When [converting to a validation rule string](https://github.com/laravel/framework/blob/9edd46fc6dcd550e4fd5d081bea37b0a43162165/src/Illuminate/Validation/Rules/Unique.php#L64), the output for the above will be:

> unique:my_table,NULL,NULL,id,field_1,"foo",field_2,"bar"

However the rule is then passed through Winter's `Validation` trait where the *processValidationUniqueRule* method changes the string to the following:

> unique:mysql.my_table,NULL,NULL,id,field_1,"foo"

Notice the second *where* clause is stripped entirely.

## The Fix

Simply `explode` the string to the same length as the `list()` so all subsequent where clauses are included in the `$whereValue` variable.

New output is:

> unique:mysql.my_table,NULL,NULL,id,field_1,"foo",field_2,"bar"