### PR TITLE
Reduce the calls to PathResolver::resolve for speed

### DIFF
--- a/src/Halcyon/Datasource/FileDatasource.php
+++ b/src/Halcyon/Datasource/FileDatasource.php
@@ -336,7 +336,7 @@ class FileDatasource extends Datasource implements DatasourceInterface
         $path = !empty($relativePath) ? $base . '/' . $relativePath : $base;
 
         // Resolve paths with base lookup for performance
-        $base = $this->resolvedBasePaths[$base] ?? $this->resolvedBasePaths[$base] = PathResolver::resolve($base);
+        $base = $this->resolvedBasePaths[$base] ?? ($this->resolvedBasePaths[$base] = PathResolver::resolve($base));
         $path = PathResolver::resolve($path);
 
         // Limit paths to those under the configured basePath + directory combo

--- a/src/Halcyon/Datasource/FileDatasource.php
+++ b/src/Halcyon/Datasource/FileDatasource.php
@@ -36,7 +36,7 @@ class FileDatasource extends Datasource implements DatasourceInterface
      *
      * @var array
      */
-    protected $pathResolverMap = [];
+    protected $resolvedBasePaths = [];
 
     /**
      * Create a new datasource instance.
@@ -336,7 +336,7 @@ class FileDatasource extends Datasource implements DatasourceInterface
         $path = !empty($relativePath) ? $base . '/' . $relativePath : $base;
 
         // Resolve paths with base lookup for performance
-        $base = $this->pathResolverMap[$base] ?? $this->pathResolverMap[$base] = PathResolver::resolve($base);
+        $base = $this->resolvedBasePaths[$base] ?? $this->resolvedBasePaths[$base] = PathResolver::resolve($base);
         $path = PathResolver::resolve($path);
 
         // Limit paths to those under the configured basePath + directory combo

--- a/src/Halcyon/Datasource/FileDatasource.php
+++ b/src/Halcyon/Datasource/FileDatasource.php
@@ -332,8 +332,8 @@ class FileDatasource extends Datasource implements DatasourceInterface
      */
     protected function makeDirectoryPath($dirName, $relativePath = '')
     {
-        $base = $this->basePath . DIRECTORY_SEPARATOR . $dirName;
-        $path = !empty($relativePath) ? $base . DIRECTORY_SEPARATOR . $relativePath : $base;
+        $base = $this->basePath . '/' . $dirName;
+        $path = !empty($relativePath) ? $base . '/' . $relativePath : $base;
 
         // Resolve paths with base lookup for performance
         $base = $this->pathResolverMap[$base] ?? $this->pathResolverMap[$base] = PathResolver::resolve($base);


### PR DESCRIPTION
During the Halcyon query for CMS pages, `FileDatasource::makeDirectoryPath` is called to generate the record file path. 

Within that method we call `PathResolver::within` to validate that the file found exsits within the base path of the model. 

Internally that method calls resolve on each arg passed, then returns `starts_with` which is fine, the issue is in the resolve method.

When returning, the `$path` var is resolved once again.

This PR reduces the calls to `PathResolver::resolve` by remembering the base path once initially resolved, then handling the `$path` var's resolution within the method scope so it can be tested and returned without needing to be resolved for a second time.

The following are messurements of the time it has taken the `while` loop in `FileDatasource::select` to execute (in seconds).

All testing has been done with 1000 CMS pages.

![Timeing changes](https://user-images.githubusercontent.com/31214002/119163577-700ec480-ba53-11eb-868d-8ad1341ea3b9.png)
