### PR TITLE
Impersonation improvements

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -736,7 +736,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
 
         if (!$canImpersonate) {
             // @TODO: translate / make exception more specific
-            throw new Exception("You cannot impersonate the selected user.");
+            throw new Exception('You cannot impersonate the selected user.');
         }
 
         // Impersonate the requested user by becoming them in the request & the session

--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -705,10 +705,16 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
      */
     public function impersonate($impersonatee)
     {
-        // Get the current user, i.e. the "impersonator"
-        $userArray = $this->getPersistCodeFromSession();
-        $impersonatorId = $userArray ? $userArray[0] : null;
-        $impersonator = $impersonatorId ? $this->findUserById($impersonatorId) : false;
+        // If the session is already being impersonated, then use the original impersonator
+        if ($this->isImpersonator()) {
+            $impersonator = $this->getImpersonator() ?: false;
+            $impersonatorId = $impersonator ? $impersonator->id : null;
+        } else {
+            // Get the current user
+            $userArray = $this->getPersistCodeFromSession();
+            $impersonatorId = $userArray ? $userArray[0] : null;
+            $impersonator = $impersonatorId ? $this->findUserById($impersonatorId) : false;
+        }
 
         /**
          * @event model.auth.beforeImpersonate

--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -828,4 +828,18 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
 
         return $this->createUserModel()->find($impersonatorId);
     }
+
+    /**
+     * Gets the user for the request, taking into account impersonation
+     *
+     * @return mixed (Models\User || null)
+     */
+    public function getRealUser()
+    {
+        if ($impersonator = $this->getImpersonator()) {
+            return $impersonator;
+        } else {
+            return $this->getUser();
+        }
+    }
 }

--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -764,7 +764,8 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
         if ($impersonateeId && ($impersonatee = $this->findUserById($impersonateeId))) {
             /**
              * @event model.auth.afterImpersonate
-             * Called after the model is booted
+             * Called after the user in question has stopped being impersonated. Current user is false when
+             * either the system or a user from a separate authentication system authorized the impersonation.
              *
              * Example usage:
              *

--- a/src/Auth/Models/User.php
+++ b/src/Auth/Models/User.php
@@ -395,7 +395,9 @@ class User extends Model implements \Illuminate\Contracts\Auth\Authenticatable
     }
 
     /**
-     * Returns an array of merged permissions for each group the user is in.
+     * Returns an array of merged permissions based on the user's individual
+     * permissions and their group permissions
+     *
      * @return array
      */
     public function getMergedPermissions()
@@ -658,5 +660,20 @@ class User extends Model implements \Illuminate\Contracts\Auth\Authenticatable
     public function getRandomString($length = 42)
     {
         return Str::random($length);
+    }
+
+    //
+    // Impersonation
+    //
+
+    /**
+     * Check if this user can be impersonated by the provided impersonator
+     *
+     * @param static|false $impersonator The user attempting to impersonate this user, false when not available
+     * @return boolean
+     */
+    public function canBeImpersonated($impersonator = false)
+    {
+        return true;
     }
 }

--- a/src/Auth/Models/User.php
+++ b/src/Auth/Models/User.php
@@ -669,7 +669,7 @@ class User extends Model implements \Illuminate\Contracts\Auth\Authenticatable
     /**
      * Check if this user can be impersonated by the provided impersonator
      *
-     * @param static|false $impersonator The user attempting to impersonate this user, false when not available
+     * @param \Winter\Storm\Auth\Models\User|false $impersonator The user attempting to impersonate this user, false when not available
      * @return boolean
      */
     public function canBeImpersonated($impersonator = false)


### PR DESCRIPTION
This add several improvements to the impersonation functionality present in Winter CMS:

- The `User` model now has a new method: `canBeImpersonated()` that receives the `$impersonator` if there is one and `false` if there isn't. This allows the impersonated user to decide if they want to be impersonated or not and makes it easy to extend the default logic for whatever custom system is desired.
- The `model.user.beforeImpersonate` event has been changed to a halting event so that third party plugins are able to override the default return values from `canBeImpersonated()` to implement more or less strict impersonation protection policies as desired on a per project basis by returning a boolean flag indicating if the user can be impersonated or not
- The `getMergedPermissions()` method in `Backend\Models\User` now will filter available permissions by the current impersonator to prevent impersonators from having more access to the system than they otherwise would have.

>**NOTE**: Feedback would be highly appreciated on this and the related PRs in wintercms/winter and wintercms/wn-user-plugin.

Related PRs:
- wintercms/winter#273
- wintercms/wn-user-plugin#10


Below is a brain dump on the subject along with some references of how other systems implement user impersonation:

# Auth Manager notes:

## User Impersonation:

Use Cases:
- Testing and debugging without requiring access to other user's credentials or having to go through the login flow


- Testing access levels
- Seeing what the user sees for support
- Allowing system services to act as a user


Current Implementation:
- Logic for all implementations of AuthManager handled in base AuthManager
- Backend:
    - Session Key: admin_auth
    - Model: Backend\Models\User
    - Users controller: update_onImpersonateUser($id);
        - requires `backend.impersonate_users` permission as only layer of protection
        - redirects to backend user myaccount page when done
- Winter.User:
    - Session Key: user_auth
    - Model: Winter\User\Models\User
    - Implemented in https://github.com/wintercms/wn-user-plugin/commit/048b155329ef39623708be468324da2a88495922
    - Meant solely for backend users to "impersonate" (i.e. just login as frontend users)
    - Impersonate method called when a user might not even be logged in under the user_auth manager
    - Requires `winter.users.impersonate_user` permission

Considerations:
- Always need to be able to identify an impersonated user as being impersonated
- Only authorized users should be able to impersonate other users
- Logs must be able to correctly identify the actual user operating the account
- Multiple authentication systems can be using the same code at the same time
- Read only access for impersonating users may be desired in some cases but undesired in others
- Users shouldn't be able to impersonate themselves
- Users shouldn't be able to impersonate someone with more access than they have
- It should be obvious when you are impersonating another person's account
    - Header banner
    - Display of username includes (Impersonating) text
- how to handle impersonating of users that shouldn't have access (deleted / archived, unactivated, banned, throttled, etc)

Other examples in the wild:
- su command in unix
- https://github.com/viacreative/sudo-su
    - stores flag when impersonating
    - stores original user ID in session
    - provides way to get the original user and identify when impersonating
    - configuration for what the user model is, assumes imperonsator and impersonatee are the same model
    - user input = impersonateeID & impersonatorID
- https://github.com/OctopyID/LaraPersonate
    - stores previous user
    - checks if user can be impersonated and if impersonater can impersonate
    - configuration for what the user model is, assumes imperonsator and impersonatee are the same model
- https://github.com/404labfr/laravel-impersonate
    - uses a trait on the user model
    - provides route middleware for preventing access to routes when the user is being impersonated
- https://docs.laravel-enso.com/backend/impersonate.html#installation
- https://pineco.de/impersonating-users/
    - "Sometimes we face situations when all the tests are passing, we find no bugs, but still, on our users’ part, something broke. By impersonating our users, we can see what they see and track the bugs down easily."
- https://mauricius.dev/easily-impersonate-any-user-in-a-laravel-application/
    - "see the application from their point of view, without having to log out and log in again"
    - "you want to recreate a bug encountered by one of your users, without having them to share their password with you."
    - Auth::once() logs in without session or cookies
- https://tenancyforlaravel.com/docs/v3/features/user-impersonation/
- https://help.channeltivity.com/support/solutions/articles/3000066767-what-is-user-impersonation-and-how-do-i-impersonate-a-user-
    - Role based
- https://cloud.google.com/iam/docs/impersonating-service-accounts
    - Explicit configuration per user of what user roles / records they are permitted to act as
    - List of members that can impersonate the account on the account itself
    - https://cloud.google.com/iam/docs/impersonating-service-accounts#allow-impersonation
- https://docs.servicenow.com/bundle/quebec-platform-administration/page/administer/users-and-groups/concept/c_ImpersonateAUser.html
    - Logs actions taken as being done by the impersonatee
    - Permissions the impersonator doesn't have access to are not avaiable while acting as the impersonatee (even if the impersonatee has those permissions)
    - impersonators can't update the password (or presumably the email address of impersonatees)
- https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation
- https://docs.microsoft.com/en-us/exchange/client-developer/exchange-web-services/impersonation-and-ews-in-exchange
- https://opendistro.github.io/for-elasticsearch-docs/docs/security/access-control/impersonation/
- https://support.google.com/admanager/answer/1241070?hl=en ("Impersonator as Impersonatee" in account view)
- https://help.docebo.com/hc/en-us/articles/360020125239-Impersonating-a-User-or-a-Power-User