### PR TITLE
Implmented hasUser method in auth manager

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -144,6 +144,15 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
     }
 
     /**
+     * Determine if the guard has a user instance.
+     * @return bool
+     */
+    public function hasUser()
+    {
+        return isset($this->user);
+    }
+
+    /**
      * Sets the user
      */
     public function setUser(Authenticatable $user)


### PR DESCRIPTION
PR to add a fix for this error:

> PHP Fatal error:  Class Winter\Storm\Auth\Manager contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Illuminate\Contracts\Auth\Guard::hasUser) in .../vendor/winter/storm/src/Auth/Manager.php on line 11

This method was added here: [438eba7](https://github.com/laravel/framework/commit/438eba7816b6ea3531596dadd2d1cb60ef13414b#diff-c20810fd7040a993e2b4a88322113dd5e7594af6d940242042d43cd152bd9633)