### PR TITLE
Removed undot function as it has been merged into laravel core

### DIFF
--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -28,23 +28,4 @@ class Arr extends ArrHelper
 
         return $results;
     }
-
-    /**
-     * Transform a dot-notated array into a normal array.
-     *
-     * Courtesy of https://github.com/laravel/framework/issues/1851#issuecomment-20796924
-     *
-     * @param array $dotArray
-     * @return array
-     */
-    public static function undot(array $dotArray)
-    {
-        $array = [];
-
-        foreach ($dotArray as $key => $value) {
-            static::set($array, $key, $value);
-        }
-
-        return $array;
-    }
 }


### PR DESCRIPTION
The `undot` method was added to Laravel in this commit: [78637dc](https://github.com/laravel/framework/commit/78637dcc784e8c85e08490d47098cd7531dcaa81#diff-3327c2ea79edc991c709e353854136a6569c610c5342f8bff02d633391bb9f21)

It's implementation is identical to ours, therefore we can either implement the same interface or just remove the method, removing the method feels more reasonable.