### PR TITLE
Updated DotEnv call to pass repository

### DIFF
--- a/src/Foundation/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Foundation/Bootstrap/LoadEnvironmentVariables.php
@@ -1,6 +1,9 @@
 <?php namespace Winter\Storm\Foundation\Bootstrap;
 
 use Dotenv\Dotenv;
+use Dotenv\Repository\RepositoryBuilder;
+use Dotenv\Repository\Adapter\EnvConstAdapter;
+use Dotenv\Repository\Adapter\PutenvAdapter;
 use Dotenv\Exception\InvalidPathException;
 use Symfony\Component\Console\Input\ArgvInput;
 use Illuminate\Contracts\Foundation\Application;
@@ -18,7 +21,12 @@ class LoadEnvironmentVariables
         $this->checkForSpecificEnvironmentFile($app);
 
         try {
-            DotEnv::create($app->environmentPath(), $app->environmentFile())->load();
+            $repository = RepositoryBuilder::createWithNoAdapters()
+                ->addAdapter(EnvConstAdapter::class)
+                ->addWriter(PutenvAdapter::class)
+                ->make();
+
+            DotEnv::create($repository, $app->environmentPath(), $app->environmentFile())->load();
         }
         catch (InvalidPathException $e) {
             //


### PR DESCRIPTION
Adds a patch to update DotEnv usage to be compatible with changes introduced in this PR https://github.com/vlucas/phpdotenv/pull/387

I'm not sure if this is how we actually want to handle env repository long term, but in the short term this'll get the application booting :)