### PR TITLE
Updated artisan service provider to be compatible with laravel

### DIFF
--- a/src/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Foundation/Providers/ArtisanServiceProvider.php
@@ -19,7 +19,7 @@ class ArtisanServiceProvider extends ArtisanServiceProviderBase
         'ConfigClear'           => \Illuminate\Foundation\Console\ConfigClearCommand::class,
         'Down'                  => \Illuminate\Foundation\Console\DownCommand::class,
         'Environment'           => \Illuminate\Foundation\Console\EnvironmentCommand::class,
-        'KeyGenerate'           => KeyGenerateCommand::class,
+        'KeyGenerate'           => \Winter\Storm\Foundation\Console\KeyGenerateCommand::class,
         'Optimize'              => \Illuminate\Foundation\Console\OptimizeCommand::class,
         'PackageDiscover'       => \Illuminate\Foundation\Console\PackageDiscoverCommand::class,
         'QueueFailed'           => \Illuminate\Queue\Console\ListFailedCommand::class,

--- a/src/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Foundation/Providers/ArtisanServiceProvider.php
@@ -12,32 +12,36 @@ class ArtisanServiceProvider extends ArtisanServiceProviderBase
      * @var array
      */
     protected $commands = [
-        'CacheClear'      => 'command.cache.clear',
-        'CacheForget'     => 'command.cache.forget',
-        'ClearCompiled'   => 'command.clear-compiled',
-        'ConfigCache'     => 'command.config.cache',
-        'ConfigClear'     => 'command.config.clear',
-        'Down'            => 'command.down',
-        'Environment'     => 'command.environment',
-        'KeyGenerate'     => 'command.key.generate',
-        'Optimize'        => 'command.optimize',
-        'PackageDiscover' => 'command.package.discover',
-        'QueueFailed'     => 'command.queue.failed',
-        'QueueFlush'      => 'command.queue.flush',
-        'QueueForget'     => 'command.queue.forget',
-        'QueueListen'     => 'command.queue.listen',
-        'QueueRestart'    => 'command.queue.restart',
-        'QueueRetry'      => 'command.queue.retry',
-        'QueueWork'       => 'command.queue.work',
-        'RouteCache'      => 'command.route.cache',
-        'RouteClear'      => 'command.route.clear',
-        'RouteList'       => 'command.route.list',
-        'ScheduleFinish'  => \Illuminate\Console\Scheduling\ScheduleFinishCommand::class,
-        'ScheduleRun'     => \Illuminate\Console\Scheduling\ScheduleRunCommand::class,
-        'Seed'            => 'command.seed',
-        'StorageLink'     => 'command.storage.link',
-        'Up'              => 'command.up',
-        'ViewClear'       => 'command.view.clear',
+        'CacheClear'            => \Illuminate\Cache\Console\ClearCommand::class,
+        'CacheForget'           => \Illuminate\Cache\Console\ForgetCommand::class,
+        'ClearCompiled'         => \Winter\Storm\Foundation\Console\ClearCompiledCommand::class,
+        'ConfigCache'           => \Illuminate\Foundation\Console\ConfigCacheCommand::class,
+        'ConfigClear'           => \Illuminate\Foundation\Console\ConfigClearCommand::class,
+        'Down'                  => \Illuminate\Foundation\Console\DownCommand::class,
+        'Environment'           => \Illuminate\Foundation\Console\EnvironmentCommand::class,
+        'KeyGenerate'           => KeyGenerateCommand::class,
+        'Optimize'              => \Illuminate\Foundation\Console\OptimizeCommand::class,
+        'PackageDiscover'       => \Illuminate\Foundation\Console\PackageDiscoverCommand::class,
+        'QueueFailed'           => \Illuminate\Queue\Console\ListFailedCommand::class,
+        'QueueFlush'            => \Illuminate\Queue\Console\FlushFailedCommand::class,
+        'QueueForget'           => \Illuminate\Queue\Console\ForgetFailedCommand::class,
+        'QueueListen'           => \Illuminate\Queue\Console\ListenCommand::class,
+        'QueueMonitor'          => \Illuminate\Queue\Console\MonitorCommand::class,
+        'QueuePruneBatches'     => \Illuminate\Queue\Console\PruneBatchesCommand::class,
+        'QueuePruneFailedJobs'  => \Illuminate\Queue\Console\PruneFailedJobsCommand::class,
+        'QueueRestart'          => \Illuminate\Queue\Console\RestartCommand::class,
+        'QueueRetry'            => \Illuminate\Queue\Console\RetryCommand::class,
+        'QueueRetryBatch'       => \Illuminate\Queue\Console\RetryBatchCommand::class,
+        'QueueWork'             => \Illuminate\Queue\Console\WorkCommand::class,
+        'RouteCache'            => \Illuminate\Foundation\Console\RouteCacheCommand::class,
+        'RouteClear'            => \Illuminate\Foundation\Console\RouteClearCommand::class,
+        'RouteList'             => \Illuminate\Foundation\Console\RouteListCommand::class,
+        'ScheduleFinish'        => \Illuminate\Console\Scheduling\ScheduleFinishCommand::class,
+        'ScheduleRun'           => \Illuminate\Console\Scheduling\ScheduleRunCommand::class,
+        'Seed'                  => \Illuminate\Database\Console\Seeds\SeedCommand::class,
+        'StorageLink'           => \Illuminate\Foundation\Console\StorageLinkCommand::class,
+        'Up'                    => \Illuminate\Foundation\Console\UpCommand::class,
+        'ViewClear'             => \Illuminate\Foundation\Console\ViewClearCommand::class,
     ];
 
     /**
@@ -46,8 +50,8 @@ class ArtisanServiceProvider extends ArtisanServiceProviderBase
      * @var array
      */
     protected $devCommands = [
-        'Serve'             => 'command.serve',
-        'VendorPublish'     => 'command.vendor.publish',
+        'Serve'             => \Illuminate\Foundation\Console\ServeCommand::class,
+        'VendorPublish'     => \Illuminate\Foundation\Console\VendorPublishCommand::class,
     ];
 
     /**


### PR DESCRIPTION
In newer versions of laravel, the default application commands are lazy loaded in. Because of this they've switched from using the facade accessor to the class string. This change was introduced in this commit: https://github.com/laravel/framework/commit/82b212c1d797e73f658ef461b11796ca75707361

I may have missed some strings that need updating as I'm just running unit tests and fixing bugs as they pop up, but this should be a start :)