### PR TITLE
Updated test to match flysystem update

### DIFF
--- a/tests/FilesystemAdapterTest.php
+++ b/tests/FilesystemAdapterTest.php
@@ -1,17 +1,17 @@
 <?php
 
-use League\Flysystem\Adapter\Local;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\Filesystem as Flysystem;
-use Winter\Storm\Filesystem\FilesystemAdapter;
+use Illuminate\Filesystem\FilesystemAdapter;
 
 class FilesystemAdapterTest extends TestCase
 {
     public function test_it_throws_an_exception_when_trying_to_get_a_temporary_url_on_a_local_disk()
     {
-        $flysystem = new Flysystem(new Local('/tmp/app'));
-
         $this->expectException(RuntimeException::class);
 
-        (new FilesystemAdapter($flysystem))->temporaryUrl('test.jpg', \Carbon\Carbon::now()->addMinutes(5));
+        $adapter = new LocalFilesystemAdapter('/tmp/app');
+        (new FilesystemAdapter(new Flysystem($adapter), $adapter))
+            ->temporaryUrl('test.jpg', \Carbon\Carbon::now()->addMinutes(5));
     }
 }


### PR DESCRIPTION
Little path to fix the `FilesystemAdapterTest` due to the removal of `Winter\Storm\Filesystem\FilesystemAdapter` and Flysystem update