### PR TITLE
Added support for laravel asset url generation

### DIFF
--- a/src/Router/RoutingServiceProvider.php
+++ b/src/Router/RoutingServiceProvider.php
@@ -36,7 +36,8 @@ class RoutingServiceProvider extends RoutingServiceProviderBase
                 $app->rebinding(
                     'request',
                     $this->requestRebinder()
-                )
+                ),
+                $app['config']['app.asset_url'] ?? null
             );
 
             $url->setSessionResolver(function () {


### PR DESCRIPTION
This PR adds support for setting a custom asset url in config, which will then be used for url generation using the `asset()` method. This is a mirror from [`Illuminate/Routing/RoutingServiceProvider::registerUrlGenerator()`](https://github.com/laravel/framework/blob/cf8b2755c88b72eb147ee5e32eb5bc452cf6470e/src/Illuminate/Routing/RoutingServiceProvider.php#L65) which implements the same functionality.