### PR TITLE
Fix closure listener with parameters as reference

### DIFF
--- a/src/Events/Dispatcher.php
+++ b/src/Events/Dispatcher.php
@@ -135,9 +135,6 @@ class Dispatcher extends BaseDispatcher
         }
 
         foreach ($this->getListeners($event) as $listener) {
-            if ($listener instanceof SerializableClosure) {
-                $listener = $listener->getClosure();
-            }
             $response = $listener($event, $payload);
 
             // If a response is returned from the listener and event halting is enabled

--- a/src/Events/Dispatcher.php
+++ b/src/Events/Dispatcher.php
@@ -51,8 +51,7 @@ class Dispatcher extends BaseDispatcher
 
         foreach ((array) $events as $event) {
             if (Str::contains($event, '*')) {
-                $listener = Serialization::wrapClosure($listener);
-                $this->setupWildcardListen($event, $listener);
+                $this->setupWildcardListen($event, Serialization::wrapClosure($listener));
             } else {
                 $this->listeners[$event][$priority][] = $this->makeListener($listener);
 

--- a/src/Events/Dispatcher.php
+++ b/src/Events/Dispatcher.php
@@ -48,10 +48,10 @@ class Dispatcher extends BaseDispatcher
         } elseif ($listener instanceof QueuedClosure) {
             $listener = $listener->resolve();
         }
-        $listener = Serialization::wrapClosure($listener);
 
         foreach ((array) $events as $event) {
             if (Str::contains($event, '*')) {
+                $listener = Serialization::wrapClosure($listener);
                 $this->setupWildcardListen($event, $listener);
             } else {
                 $this->listeners[$event][$priority][] = $this->makeListener($listener);
@@ -59,6 +59,14 @@ class Dispatcher extends BaseDispatcher
                 unset($this->sorted[$event]);
             }
         }
+    }
+
+    // Serialize the new listener
+    public function makeListener($listener, $wildcard = false)
+    {
+        $listener = parent::makeListener($listener, $wildcard);
+
+        return Serialization::wrapClosure($listener);
     }
 
     /**

--- a/src/Events/Dispatcher.php
+++ b/src/Events/Dispatcher.php
@@ -61,7 +61,7 @@ class Dispatcher extends BaseDispatcher
         }
     }
 
-    // Serialize the new listener
+    // Serialize the listener created by laravel
     public function makeListener($listener, $wildcard = false)
     {
         $listener = parent::makeListener($listener, $wildcard);

--- a/tests/Events/DispatcherTest.php
+++ b/tests/Events/DispatcherTest.php
@@ -53,6 +53,19 @@ class DispatcherTest extends TestCase
         $this->assertTrue($magic_value);
     }
 
+    public function testClosureWithValueArgument()
+    {
+        $original = false;
+
+        $dispatcher = new Dispatcher();
+        $dispatcher->listen('test', function ($value) {
+            $value = true;
+        });
+        $dispatcher->dispatch('test', [$original]);
+
+        $this->assertFalse($original);
+    }
+
     public function testClosureWithReferenceArgument()
     {
         $original = false;

--- a/tests/Events/DispatcherTest.php
+++ b/tests/Events/DispatcherTest.php
@@ -53,6 +53,19 @@ class DispatcherTest extends TestCase
         $this->assertTrue($magic_value);
     }
 
+    public function testClosureWithReferenceArgument()
+    {
+        $original = false;
+
+        $dispatcher = new Dispatcher();
+        $dispatcher->listen('test', function (&$value) {
+            $value = true;
+        });
+        $dispatcher->dispatch('test', [&$original]);
+
+        $this->assertTrue($original);
+    }
+
     public function testStringEventPriorities()
     {
         $magic_value = 0;


### PR DESCRIPTION
The previous behavior creates a "regular" Closure for the listener we already wrap in a SerializedClosure (in Laravel's Events::Dispatcher::makeListener() method).

This PR delays creating the SerializedClosure on the initial listener and waits for the Closure returned by Laravel's makeListener() method before wrapping it into a SerializedClosure. 
