### PR TITLE
Fix Auth setPermissionsAttribute method having the wrong type-hint.

### DIFF
--- a/src/Auth/Models/Role.php
+++ b/src/Auth/Models/Role.php
@@ -161,7 +161,7 @@ class Role extends Model
 
     /**
      * Validate the permissions when set.
-     * @param  array  $permissions
+     * @param  string  $permissions
      * @return void
      */
     public function setPermissionsAttribute($permissions)

--- a/src/Auth/Models/User.php
+++ b/src/Auth/Models/User.php
@@ -558,7 +558,7 @@ class User extends Model implements \Illuminate\Contracts\Auth\Authenticatable
 
     /**
      * Validate any set permissions.
-     * @param array $permissions
+     * @param string $permissions
      * @return void
      */
     public function setPermissionsAttribute($permissions)


### PR DESCRIPTION
The User/Role Auth model `permissions` attribute mutator (setPermissionsAttribute) contains the wrong type-hint in the doc block.

`json_decode` accepts a string as the first parameter, not an array.