### PR TITLE
Use extension if provided in resizer options

### DIFF
--- a/src/Database/Attach/Resizer.php
+++ b/src/Database/Attach/Resizer.php
@@ -693,7 +693,7 @@ class Resizer
      * @param string $path The filename path
      * @return string
      */
-    protected function getExtension($path)
+    protected function getExtension(string $path): string
     {
         return $this->getOption('extension') ?: (pathinfo($path, PATHINFO_EXTENSION) ?: $this->extension);
     }

--- a/src/Database/Attach/Resizer.php
+++ b/src/Database/Attach/Resizer.php
@@ -451,7 +451,7 @@ class Resizer
         }
 
         // Determine the image type from the destination file
-        $extension = pathinfo($savePath, PATHINFO_EXTENSION) ?: $this->extension;
+        $extension = $this->getExtension($savePath);
 
         // Create and save an image based on it's extension
         switch (strtolower($extension)) {
@@ -686,5 +686,15 @@ class Resizer
         $optimalHeight = round($this->height * $effectiveRatio);
 
         return [$optimalWidth, $optimalHeight];
+    }
+
+    /**
+     * Return the filename extension for the provided filename
+     * @param string $path The filename path
+     * @return string
+     */
+    protected function getExtension($path)
+    {
+        return $this->getOption('extension') ?: (pathinfo($path, PATHINFO_EXTENSION) ?: $this->extension);
     }
 }

--- a/src/Database/Attach/Resizer.php
+++ b/src/Database/Attach/Resizer.php
@@ -689,9 +689,7 @@ class Resizer
     }
 
     /**
-     * Return the filename extension for the provided filename
-     * @param string $path The filename path
-     * @return string
+     * Get the extension for the provided filename
      */
     protected function getExtension(string $path): string
     {

--- a/tests/Database/Attach/ResizerTest.php
+++ b/tests/Database/Attach/ResizerTest.php
@@ -75,7 +75,6 @@ class ResizerTest extends TestCase
     /**
      * Given a Resizer with any image
      * Test to see if the getExtension() method properly returns the filename extension for the provided filename
-     * @throws Exception
      */
     public function testGetExtension()
     {

--- a/tests/Database/Attach/ResizerTest.php
+++ b/tests/Database/Attach/ResizerTest.php
@@ -74,6 +74,30 @@ class ResizerTest extends TestCase
 
     /**
      * Given a Resizer with any image
+     * Test to see if the getExtension() method properly returns the filename extension for the provided filename
+     * @throws Exception
+     */
+    public function testGetExtension()
+    {
+        $this->setSource(self::SRC_PORTRAIT); // gif extension
+        $this->createFixtureResizer();
+
+        // no extension provided in path, no extension provided in options, should return source extension.
+        $extension = $this->callProtectedMethod($this->resizer, 'getExtension', ['dummy']);
+        $this->assertEquals('gif', $extension);
+
+        // no extension provided in options, extension provided in path, should return path extension
+        $extension = $this->callProtectedMethod($this->resizer, 'getExtension', ['dummy.jpg']);
+        $this->assertEquals('jpg', $extension);
+
+        // extension provided in options and in path, should return extension from options
+        $this->resizer->setOptions(['extension' => 'png']);
+        $extension = $this->callProtectedMethod($this->resizer, 'getExtension', ['dummy.jpg']);
+        $this->assertEquals('png', $extension);
+    }
+
+    /**
+     * Given a Resizer with any image
      * When the resize method is called with 0x0
      * Then the saved image should be the same as the original one (size, color and transparency)
      * @throws Exception


### PR DESCRIPTION
This is required to allow converting images to other formats (e.g. webp). Otherwise the resulting file will have the correct extension but the wrong image format.

Replaces #9 since the original repo got deleted.

The following code can be used as a workaround in the meantime:
```
Event::listen('system.resizer.processResize', function ($resizer, $tempPath) {
    // Get the resizing configuration
    $config = $resizer->getConfig();
    $options = array_get($config, 'options', []);

    list($base, $ext) = explode('.', $tempPath);
    $newPath = $base . '.' . array_get($options, 'extension', $ext);

    // Resize the image
    $resizedImageContents = \Winter\Storm\Database\Attach\Resizer::open($tempPath)
        ->resize($config['width'], $config['height'], $options)
        ->save($newPath);

    if ($newPath != $tempPath) {
        File::move($newPath, $tempPath);
    }

    // Prevent any other resizing replacer logic from running
    return true;
});
```