### PR TITLE
Allow array of email addresses without names

### DIFF
--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -462,7 +462,8 @@ class Mailer extends MailerBase
 
     /**
      * Process a recipients object, which can look like the following:
-     *  - (string) admin@domain.tld
+     *  - (string) 'admin@domain.tld'
+     *  - (array) ['admin@domain.tld', 'other@domain.tld']
      *  - (object) ['email' => 'admin@domain.tld', 'name' => 'Adam Person']
      *  - (array) ['admin@domain.tld' => 'Adam Person', ...]
      *  - (array) [ (object|array) ['email' => 'admin@domain.tld', 'name' => 'Adam Person'], [...] ]
@@ -477,7 +478,10 @@ class Mailer extends MailerBase
             $result[$recipients] = null;
         } elseif (is_array($recipients) || $recipients instanceof Collection) {
             foreach ($recipients as $address => $person) {
-                if (is_string($person)) {
+                if (is_int($address) && is_string($person)) {
+                    // no name provided, only email address
+                    $result[$person] = null;
+                } elseif (is_string($person)) {
                     $result[$address] = $person;
                 } elseif (is_object($person)) {
                     if (empty($person->email) && empty($person->address)) {

--- a/tests/Mail/MailerTest.php
+++ b/tests/Mail/MailerTest.php
@@ -45,6 +45,20 @@ class MailerTest extends TestCase
         $this->assertEquals('Adam Person', $result['user@domain.tld']);
 
         /*
+         * Array of email addresses without names
+         */
+        $recipients = [
+            'admin@domain.tld',
+            'single@address.com',
+            'charles@barrington.com',
+        ];
+        $result = self::callProtectedMethod($mailer, 'processRecipients', [$recipients]);
+        $this->assertCount(3, $result);
+        $this->assertEquals('admin@domain.tld', $result[0]);
+        $this->assertEquals('single@address.com', $result[1]);
+        $this->assertEquals('charles@barrington.com', $result[2]);
+
+        /*
          * Array
          */
         $recipients = [

--- a/tests/Mail/MailerTest.php
+++ b/tests/Mail/MailerTest.php
@@ -54,9 +54,10 @@ class MailerTest extends TestCase
         ];
         $result = self::callProtectedMethod($mailer, 'processRecipients', [$recipients]);
         $this->assertCount(3, $result);
-        $this->assertEquals('admin@domain.tld', $result[0]);
-        $this->assertEquals('single@address.com', $result[1]);
-        $this->assertEquals('charles@barrington.com', $result[2]);
+        foreach ($recipients as $key => $value) {
+            $this->assertArrayHasKey($value, $result);
+            $this->assertEquals(null, $result[$value]);
+        }
 
         /*
          * Array


### PR DESCRIPTION
Properly convert an array of email addresses without names so that Symfony Mail will accept the addresses. 

Added Unit test for it as well.