### PR TITLE
Fire mailer.beforeRegister event earlier

### DIFF
--- a/src/Mail/MailManager.php
+++ b/src/Mail/MailManager.php
@@ -10,6 +10,22 @@ use Illuminate\Mail\MailManager as BaseMailManager;
  */
 class MailManager extends BaseMailManager
 {
+    /*
+     * Get a mailer instance by name.
+     *
+     * @param  string|null  $name
+     * @return \Illuminate\Contracts\Mail\Mailer
+     */
+    public function mailer($name = null)
+    {
+        /*
+         * Extensibility
+         */
+        $this->app['events']->fire('mailer.beforeRegister', [$this]);
+
+        return parent::mailer($name);
+    }
+
     /**
      * Resolve the given mailer.
      *
@@ -25,11 +41,6 @@ class MailManager extends BaseMailManager
         if (is_null($config)) {
             throw new InvalidArgumentException("Mailer [{$name}] is not defined.");
         }
-
-        /*
-         * Extensibility
-         */
-        $this->app['events']->fire('mailer.beforeRegister', [$this]);
 
         // Once we have created the mailer instance we will set a container instance
         // on the mailer. This allows us to resolve mailer classes via containers


### PR DESCRIPTION
Requires [#522](https://github.com/wintercms/winter/pull/522)

This fix is needed because if the event is fired in `resolve()` method, the $name variable has already been defined (from a call to getDefaultDriver() in the base `mailer()` method)

ref. https://github.com/laravel/framework/blob/9.x/src/Illuminate/Mail/MailManager.php#L70

Note: if the $name argument is provided to the mailer() method, the problem does not occur because the config is forced to that driver name.