### PR TITLE
Restored mail dispatcher being passed correct message obj

### DIFF
--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -159,7 +159,7 @@ class Mailer extends MailerBase
             if ($symfonySentMessage) {
                 $sentMessage = new SentMessage($symfonySentMessage);
 
-                $this->dispatchSentEvent($sentMessage, $data);
+                $this->dispatchSentEvent($message, $data);
 
                 /**
                  * @event mailer.send


### PR DESCRIPTION
PR fixes the following error `Call to undefined method Illuminate\Mail\SentMessage::getSymfonyMessage()` when attempting to send mail via the reset password feature.

The issue is we're calling `dispatchSentEvent()` in `src/Mail/Mailer.php:161` and passing `Illuminate\Mail\SentMessage` instead of `Illuminate\Mail\Message`.