### PR TITLE
Add config['local_domain'] for smtp transport (default is [127.0.0.1])

### DIFF
--- a/src/Mail/MailManager.php
+++ b/src/Mail/MailManager.php
@@ -42,6 +42,12 @@ class MailManager extends BaseMailManager
             throw new InvalidArgumentException("Mailer [{$name}] is not defined.");
         }
 
+        $transport = $config['transport'] ?? $this->app['config']['mail.driver'];
+
+        if ($transport === 'smtp' && !array_key_exists('local_domain', $config)) {
+            $config['local_domain'] = gethostbyaddr(gethostbyname(gethostname()));
+        }
+
         // Once we have created the mailer instance we will set a container instance
         // on the mailer. This allows us to resolve mailer classes via containers
         // for maximum testability on said classes instead of passing Closures.

--- a/src/Mail/MailManager.php
+++ b/src/Mail/MailManager.php
@@ -45,6 +45,9 @@ class MailManager extends BaseMailManager
         $transport = $config['transport'] ?? $this->app['config']['mail.driver'];
 
         if ($transport === 'smtp' && !array_key_exists('local_domain', $config)) {
+            // if local_domain is not set in config, symfony smtp transport will use its
+            // default value ([127.0.0.1]) when sending HELO smtp command to remote smtp server.
+            // ref. symfony/mailer/Transport/Smtp/SmtpTransport.php
             $config['local_domain'] = gethostbyaddr(gethostbyname(gethostname()));
         }
 


### PR DESCRIPTION
Without this, connecting to google smtp relay server fails with SMTP code 421 after the HELO command.