### PR TITLE
Bring Translator closer to base Laravel functionality, add "set" method

### DIFF
--- a/src/Translation/FileLoader.php
+++ b/src/Translation/FileLoader.php
@@ -29,10 +29,12 @@ class FileLoader extends FileLoaderBase
         // Try "xx-xx" format
         $locale = str_replace('_', '-', strtolower($locale));
 
-        $file = "{$this->path}/{$locale}/{$namespace}/{$group}.php";
+        if ("{$this->path}/{$locale}/{$namespace}/{$group}.php" !== $file) {
+            $file = "{$this->path}/{$locale}/{$namespace}/{$group}.php";
 
-        if ($this->files->exists($file)) {
-            return array_replace_recursive($lines, $this->files->getRequire($file));
+            if ($this->files->exists($file)) {
+                return array_replace_recursive($lines, $this->files->getRequire($file));
+            }
         }
 
         return $lines;
@@ -58,8 +60,10 @@ class FileLoader extends FileLoaderBase
         // Try "xx-xx" format
         $locale = str_replace('_', '-', strtolower($locale));
 
-        if ($this->files->exists($full = "{$path}/{$locale}/{$group}.php")) {
-            return $this->files->getRequire($full);
+        if ("{$path}/{$locale}/{$group}.php" !== $full) {
+            if ($this->files->exists($full = "{$path}/{$locale}/{$group}.php")) {
+                return $this->files->getRequire($full);
+            }
         }
 
         return [];

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -72,7 +72,17 @@ class Translator extends TranslatorBase
 
             $this->load('*', '*', $locale);
 
-            $this->loaded['*']['*'][$locale][$key] = $value;
+            if (is_array($value)) {
+                foreach ($value as $langKey => $langValue) {
+                    if (is_array($langValue)) {
+                        $this->set($key . '.' . $langKey, $langValue, $locale);
+                    } else {
+                        $this->loaded['*']['*'][$locale][$key . '.' . $langKey] = $langValue;
+                    }
+                }
+            } else {
+                $this->loaded['*']['*'][$locale][$key] = $value;
+            }
         }
     }
 

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -49,26 +49,6 @@ class Translator extends TranslatorBase
      */
     public function get($key, array $replace = [], $locale = null, $fallback = true)
     {
-        /**
-         * @event translator.beforeResolve
-         * Fires before the translator resolves the requested language key
-         *
-         * >**NOTE:** It is highly recommended to use [project level localization overrides](https://wintercms.com/docs/plugin/localization#overriding) before reaching for this event.
-         *
-         * Example usage (overrides the value returned for a specific language key):
-         *
-         *     Event::listen('translator.beforeResolve', function ((string) $key, (array) $replace, (string|null) $locale) {
-         *         if ($key === 'my.custom.key') {
-         *             return 'My overriding value';
-         *         }
-         *     });
-         *
-         */
-        if (isset($this->events) &&
-            ($line = $this->events->fire('translator.beforeResolve', [$key, $replace, $locale], true))) {
-            return $line;
-        }
-
         if ($line = $this->getValidationSpecific($key, $replace, $locale)) {
             return $line;
         }

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -90,6 +90,8 @@ class Translator extends TranslatorBase
         } else {
             $locale = $locale ?: $this->locale;
 
+            $this->load('*', '*', $locale);
+
             $this->loaded['*']['*'][$locale][$key] = $value;
         }
     }
@@ -175,7 +177,7 @@ class Translator extends TranslatorBase
      */
     protected function localeArray($locale)
     {
-        $locales = array_filter([$locale ?: $this->locale, $this->fallback, static::CORE_LOCALE]);
+        $locales = array_values(array_filter([$locale ?: $this->locale, $this->fallback, static::CORE_LOCALE]));
 
         return call_user_func($this->determineLocalesUsing ?: fn () => $locales, $locales);
     }

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -11,8 +11,6 @@ use Illuminate\Translation\Translator as TranslatorBase;
  */
 class Translator extends TranslatorBase
 {
-    use \Winter\Storm\Support\Traits\KeyParser;
-
     const CORE_LOCALE = 'en';
 
     /**
@@ -71,55 +69,29 @@ class Translator extends TranslatorBase
             return $line;
         }
 
-        $locale = $locale ?: $this->locale;
-
-        // For JSON translations, there is only one file per locale, so we will simply load
-        // that file and then we will be ready to check the array for the key. These are
-        // only one level deep so we do not need to do any fancy searching through it.
-        $this->load('*', '*', $locale);
-
-        $line = $this->loaded['*']['*'][$locale][$key] ?? null;
-
-        // If we can't find a translation for the JSON key, we will attempt to translate it
-        // using the typical translation file. This way developers can always just use a
-        // helper such as __ instead of having to pick between trans or __ with views.
-        if (!isset($line)) {
-            if ($line = $this->getValidationSpecific($key, $replace, $locale)) {
-                return $line;
-            }
-
-            list($namespace, $group, $item) = $this->parseKey($key);
-
-            if (is_null($namespace)) {
-                $namespace = '*';
-            }
-
-            // Here we will get the locale that should be used for the language line. If one
-            // was not passed, we will use the default locales which was given to us when
-            // the translator was instantiated. Then, we can load the lines and return.
-            foreach ($this->parseLocale($locale, $fallback) as $locale) {
-                $line = $this->getLine(
-                    $namespace,
-                    $group,
-                    $locale,
-                    $item,
-                    $replace
-                );
-
-                if (!is_null($line)) {
-                    break;
-                }
-            }
+        if ($line = $this->getValidationSpecific($key, $replace, $locale)) {
+            return $line;
         }
 
-        // If the line doesn't exist, we will return back the key which was requested as
-        // that will be quick to spot in the UI if language keys are wrong or missing
-        // from the application's language files. Otherwise we can return the line.
-        if (!isset($line)) {
-            return $this->makeReplacements($key, $replace);
-        }
+        return parent::get($key, $replace, $locale, $fallback);
+    }
 
-        return $line;
+    /**
+     * Set the language string value for a given key in a given locale.
+     *
+     * If no locale is provided, the language string will be set for the default locale.
+     */
+    public function set(array|string $key, array|string|null $value = null, ?string $locale = null): void
+    {
+        if (is_array($key)) {
+            foreach ($key as $itemKey => $itemValue) {
+                $this->set($itemKey, $itemValue, $locale);
+            }
+        } else {
+            $locale = $locale ?: $this->locale;
+
+            $this->loaded['*']['*'][$locale][$key] = $value;
+        }
     }
 
     /**
@@ -162,54 +134,18 @@ class Translator extends TranslatorBase
     }
 
     /**
-     * Get a translation according to an integer value.
-     *
-     * @param  string  $key
-     * @param  int|array|\Countable  $number
-     * @param  array   $replace
-     * @param  string  $locale
-     * @return string
+     * @inheritDoc
      */
-    public function choice($key, $number, array $replace = [], $locale = null)
+    protected function localeForChoice($locale)
     {
-        $line = $this->get(
-            $key,
-            $replace,
-            $locale = $this->localeForChoice($locale)
-        );
+        $locale = parent::localeForChoice($locale);
 
-        // If the given "number" is actually an array or countable we will simply count the
-        // number of elements in an instance. This allows developers to pass an array of
-        // items without having to count it on their end first which gives bad syntax.
-        if (is_array($number) || $number instanceof Countable) {
-            $number = count($number);
-        }
-
-        // Format locale for MessageSelector
-        if (strpos($locale, '-') !== false) {
+        if (!is_null($locale) && str_contains($locale, '-')) {
             $localeParts = explode('-', $locale, 2);
             $locale = $localeParts[0] . '_' . strtoupper($localeParts[1]);
         }
 
-        $replace['count'] = $number;
-
-        return $this->makeReplacements($this->getSelector()->choose($line, $number, $locale), $replace);
-    }
-
-    /**
-     * Get the array of locales to be checked.
-     *
-     * @param  string|null  $locale
-     * @param  bool         $fallback
-     * @return array
-     */
-    protected function parseLocale($locale, $fallback)
-    {
-        $locales = $fallback ? $this->localeArray($locale) : [$locale ?: $this->locale];
-
-        $locales[] = static::CORE_LOCALE;
-
-        return $locales;
+        return $locale;
     }
 
     /**
@@ -232,7 +168,20 @@ class Translator extends TranslatorBase
     }
 
     /**
-     * Register a namespace alias
+     * Get the array of locales to be checked.
+     *
+     * @param  string|null  $locale
+     * @return array
+     */
+    protected function localeArray($locale)
+    {
+        $locales = array_filter([$locale ?: $this->locale, $this->fallback, static::CORE_LOCALE]);
+
+        return call_user_func($this->determineLocalesUsing ?: fn () => $locales, $locales);
+    }
+
+    /**
+     * Register a namespace alias.
      *
      * @param string $namespace The namespace to register an alias for. Example: winter.blog
      * @param string $alias The alias to register. Example: rainlab.blog

--- a/tests/Translation/FileLoaderTest.php
+++ b/tests/Translation/FileLoaderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Winter\Storm\Filesystem\Filesystem;
+use Winter\Storm\Translation\FileLoader;
+use Mockery as m;
+
+/**
+ * These tests were adapted from the Laravel 9.x test cases to ensure our functionality still
+ * provides the base functionality.
+ *
+ * Credits: https://github.com/laravel
+ */
+class FileLoaderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testLoadMethodWithoutNamespacesProperlyCallsLoader()
+    {
+        $loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/en/foo.php')->andReturn(['messages']);
+
+        $this->assertEquals(['messages'], $loader->load('en', 'foo', null));
+    }
+
+    public function testLoadMethodWithNamespacesProperlyCallsLoader()
+    {
+        $loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
+        $files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en/namespace/foo.php')->andReturn(false);
+        $files->shouldReceive('getRequire')->once()->with('bar/en/foo.php')->andReturn(['foo' => 'bar']);
+        $loader->addNamespace('namespace', 'bar');
+
+        $this->assertEquals(['foo' => 'bar'], $loader->load('en', 'foo', 'namespace'));
+    }
+
+    public function testLoadMethodWithNamespacesProperlyCallsLoaderAndLoadsLocalOverrides()
+    {
+        $loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
+        $files->shouldReceive('exists')->once()->with('bar/en/foo.php')->andReturn(true);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en/namespace/foo.php')->andReturn(true);
+        $files->shouldReceive('getRequire')->once()->with('bar/en/foo.php')->andReturn(['foo' => 'bar']);
+        $files->shouldReceive('getRequire')->once()->with(__DIR__.'/en/namespace/foo.php')->andReturn(['foo' => 'override', 'baz' => 'boom']);
+        $loader->addNamespace('namespace', 'bar');
+
+        $this->assertEquals(['foo' => 'override', 'baz' => 'boom'], $loader->load('en', 'foo', 'namespace'));
+    }
+
+    public function testEmptyArraysReturnedWhenFilesDontExist()
+    {
+        $loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en/foo.php')->andReturn(false);
+        $files->shouldReceive('getRequire')->never();
+
+        $this->assertEquals([], $loader->load('en', 'foo', null));
+    }
+
+    public function testEmptyArraysReturnedWhenFilesDontExistForNamespacedItems()
+    {
+        $loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
+        $files->shouldReceive('getRequire')->never();
+
+        $this->assertEquals([], $loader->load('en', 'foo', 'bar'));
+    }
+
+    public function testLoadMethodForJSONProperlyCallsLoader()
+    {
+        $loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(true);
+        $files->shouldReceive('get')->once()->with(__DIR__.'/en.json')->andReturn('{"foo":"bar"}');
+
+        $this->assertEquals(['foo' => 'bar'], $loader->load('en', '*', '*'));
+    }
+
+    public function testLoadMethodForJSONProperlyCallsLoaderForMultiplePaths()
+    {
+        $loader = new FileLoader($files = m::mock(Filesystem::class), __DIR__);
+        $loader->addJsonPath(__DIR__.'/another');
+
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/en.json')->andReturn(true);
+        $files->shouldReceive('exists')->once()->with(__DIR__.'/another/en.json')->andReturn(true);
+        $files->shouldReceive('get')->once()->with(__DIR__.'/en.json')->andReturn('{"foo":"bar"}');
+        $files->shouldReceive('get')->once()->with(__DIR__.'/another/en.json')->andReturn('{"foo":"backagebar", "baz": "backagesplash"}');
+
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'backagesplash'], $loader->load('en', '*', '*'));
+    }
+}

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -1,10 +1,20 @@
 <?php
 
+use Illuminate\Contracts\Translation\Loader;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use Illuminate\Translation\MessageSelector;
+use Mockery as m;
 use Winter\Storm\Events\Dispatcher;
 use Winter\Storm\Translation\FileLoader;
 use Winter\Storm\Translation\Translator;
 
+/**
+ * Some tests were adapted from the Laravel 9.x test cases to ensure our functionality still
+ * provides the base functionality.
+ *
+ * Credits: https://github.com/laravel
+ */
 class TranslatorTest extends TestCase
 {
     /**
@@ -16,11 +26,275 @@ class TranslatorTest extends TestCase
     {
         parent::setUp();
 
-        $path       = __DIR__ . '/../fixtures/lang';
+        $path = __DIR__ . '/../fixtures/lang';
         $fileLoader = new FileLoader(new Filesystem(), $path);
         $translator = new Translator($fileLoader, 'en');
         $translator->addNamespace('winter.test', $path);
         $this->translator = $translator;
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    protected function getLoader()
+    {
+        return m::mock(Loader::class);
+    }
+
+    public function testHasMethodReturnsFalseWhenReturnedTranslationIsNull()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('foo');
+        $this->assertFalse($t->has('foo', 'bar'));
+
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en', 'sp'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'))->willReturn('bar');
+        $this->assertTrue($t->has('foo', 'bar'));
+
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('bar');
+        $this->assertTrue($t->hasForLocale('foo', 'bar'));
+
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo([]), $this->equalTo('bar'), false)->willReturn('foo');
+        $this->assertFalse($t->hasForLocale('foo', 'bar'));
+
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['foo' => 'bar']);
+        $this->assertTrue($t->hasForLocale('foo'));
+
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
+        $this->assertFalse($t->hasForLocale('foo'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesItem()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo']]);
+        $this->assertEquals(['tree bar', 'breeze bar'], $t->get('foo::bar.qux', ['foo' => 'bar'], 'en'));
+        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesArrayItem()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo', 'beep' => ['rock' => 'tree :foo']]]);
+        $this->assertEquals(['foo' => 'foo', 'baz' => 'breeze bar', 'qux' => ['tree bar', 'breeze bar', 'beep' => ['rock' => 'tree bar']]], $t->get('foo::bar', ['foo' => 'bar'], 'en'));
+        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testGetMethodForNonExistingReturnsSameKey()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo', 'qux' => ['tree :foo', 'breeze :foo']]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'unknown', 'foo')->andReturn([]);
+        $this->assertSame('foo::unknown', $t->get('foo::unknown', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo::bar.unknown', $t->get('foo::bar.unknown', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo::unknown.bar', $t->get('foo::unknown.bar'));
+    }
+
+    public function testTransMethodProperlyLoadsAndRetrievesItemWithHTMLInTheMessage()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze <p>test</p>']);
+        $this->assertSame('breeze <p>test</p>', $t->get('foo.bar', [], 'en'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesItemWithCapitalization()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods([])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :0 :Foo :BAR']);
+        $this->assertSame('breeze john Bar FOO', $t->get('foo::bar.baz', ['john', 'foo' => 'bar', 'bar' => 'foo'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesItemWithLongestReplacementsFirst()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo :foobar']);
+        $this->assertSame('breeze bar taylor', $t->get('foo::bar.baz', ['foo' => 'bar', 'foobar' => 'taylor'], 'en'));
+        $this->assertSame('breeze foo bar baz taylor', $t->get('foo::bar.baz', ['foo' => 'foo bar baz', 'foobar' => 'taylor'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesItemForFallback()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->setFallback('lv');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'bar', 'foo')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('lv', 'bar', 'foo')->andReturn(['foo' => 'foo', 'baz' => 'breeze :foo']);
+        $this->assertSame('breeze bar', $t->get('foo::bar.baz', ['foo' => 'bar'], 'en'));
+        $this->assertSame('foo', $t->get('foo::bar.foo'));
+    }
+
+    public function testGetMethodProperlyLoadsAndRetrievesItemForGlobalNamespace()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'breeze :foo']);
+        $this->assertSame('breeze bar', $t->get('foo.bar', ['foo' => 'bar']));
+    }
+
+    public function testSetMethodProperlySetsItem()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->set('foo', 'bar');
+        $this->assertSame('bar', $t->get('foo'));
+    }
+
+    public function testSetMethodOverwritesPreviouslyLoadedItem()
+    {
+        $this->assertEquals('Hello Winter!', $this->translator->get('winter.test::lang.test.hello_winter'));
+
+        $this->translator->set('winter.test::lang.test.hello_winter', 'Hi Winter!');
+
+        $this->assertEquals('Hi Winter!', $this->translator->get('winter.test::lang.test.hello_winter'));
+    }
+
+    public function testSetMethodDoesNotPreventOtherLanguageStringsBeingLoadedNormally()
+    {
+        $path = __DIR__ . '/../fixtures/lang';
+        $fileLoader = new FileLoader(new Filesystem(), $path);
+        $translator = new Translator($fileLoader, 'en');
+
+        // Set value first
+        $translator->set('winter.test::lang.test.hello_winter', 'Hi Winter!');
+
+        // Then, add the namespace
+        $translator->addNamespace('winter.test', $path);
+
+        $this->assertEquals('Hi Winter!', $translator->get('winter.test::lang.test.hello_winter'));
+
+        // This should now be translated
+        $this->assertEquals('Welcome to Winter!', $translator->get('winter.test::lang.test.welcome_to_winter'));
+    }
+
+    public function testChoiceMethodProperlyLoadsAndRetrievesItem()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->once())->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->setSelector($selector = m::mock(MessageSelector::class));
+        $selector->shouldReceive('choose')->once()->with('line', 10, 'en')->andReturn('choiced');
+
+        $t->choice('foo', 10, ['replace']);
+    }
+
+    public function testChoiceMethodProperlyCountsCollectionsAndLoadsAndRetrievesItem()
+    {
+        $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();
+        $t->expects($this->exactly(2))->method('get')->with($this->equalTo('foo'), $this->equalTo(['replace']), $this->equalTo('en'))->willReturn('line');
+        $t->setSelector($selector = m::mock(MessageSelector::class));
+        $selector->shouldReceive('choose')->twice()->with('line', 3, 'en')->andReturn('choiced');
+
+        $values = ['foo', 'bar', 'baz'];
+        $t->choice('foo', $values, ['replace']);
+
+        $values = new Collection(['foo', 'bar', 'baz']);
+        $t->choice('foo', $values, ['replace']);
+    }
+
+    public function testGetJson()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo' => 'one']);
+        $this->assertSame('one', $t->get('foo'));
+    }
+
+    public function testGetJsonReplaces()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i:c :u' => 'bar :i:c :u']);
+        $this->assertSame('bar onetwo three', $t->get('foo :i:c :u', ['i' => 'one', 'c' => 'two', 'u' => 'three']));
+    }
+
+    public function testGetJsonHasAtomicReplacements()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['Hello :foo!' => 'Hello :foo!']);
+        $this->assertSame('Hello baz:bar!', $t->get('Hello :foo!', ['foo' => 'baz:bar', 'bar' => 'abcdef']));
+    }
+
+    public function testGetJsonReplacesForAssociativeInput()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['foo :i :c' => 'bar :i :c']);
+        $this->assertSame('bar eye see', $t->get('foo :i :c', ['i' => 'eye', 'c' => 'see']));
+    }
+
+    public function testGetJsonPreservesOrder()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn(['to :name I give :greeting' => ':greeting :name']);
+        $this->assertSame('Greetings David', $t->get('to :name I give :greeting', ['name' => 'David', 'greeting' => 'Greetings']));
+    }
+
+    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeys()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one']);
+        $this->assertSame('one', $t->get('foo.bar'));
+    }
+
+    public function testGetJsonForNonExistingJsonKeyLooksForRegularKeysAndReplace()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn(['bar' => 'one :message']);
+        $this->assertSame('one two', $t->get('foo.bar', ['message' => 'two']));
+    }
+
+    public function testGetJsonForNonExistingReturnsSameKey()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'Foo that bar', '*')->andReturn([]);
+        $this->assertSame('Foo that bar', $t->get('Foo that bar'));
+    }
+
+    public function testGetJsonForNonExistingReturnsSameKeyAndReplaces()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
+        $this->assertSame('foo baz', $t->get('foo :message', ['message' => 'baz']));
+    }
+
+    public function testEmptyFallbacks()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo :message', '*')->andReturn([]);
+        $this->assertSame('foo ', $t->get('foo :message', ['message' => null]));
+    }
+
+    public function testDetermineLocalesUsingMethod()
+    {
+        $t = new Translator($this->getLoader(), 'en');
+        $t->determineLocalesUsing(function ($locales) {
+            $this->assertSame(['en', 'en'], $locales);
+
+            return ['en', 'lz'];
+        });
+        $t->getLoader()->shouldReceive('load')->once()->with('en', '*', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('en', 'foo', '*')->andReturn([]);
+        $t->getLoader()->shouldReceive('load')->once()->with('lz', 'foo', '*')->andReturn([]);
+        $this->assertSame('foo', $t->get('foo'));
     }
 
     public function testSimilarWordsParsing()

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -50,15 +50,25 @@ class TranslatorTest extends TestCase
      */
     public function testChoiceSublocale()
     {
-        $this->translator->setLocale('en-au');
-
         $this->assertEquals(
-            'Page',
-            $this->translator->choice('lang.test.choice', 1)
+            'mom',
+            $this->translator->choice('lang.test.mother', 1)
         );
         $this->assertEquals(
-            'Pages',
-            $this->translator->choice('lang.test.choice', 2)
+            'moms',
+            $this->translator->choice('lang.test.mother', 2)
+        );
+
+        $this->translator->setLocale('en-gb');
+
+        $this->assertEquals(
+            'mum',
+            $this->translator->choice('lang.test.mother', 1)
+        );
+
+        $this->assertEquals(
+            'mums',
+            $this->translator->choice('lang.test.mother', 2)
         );
     }
 

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -346,19 +346,6 @@ class TranslatorTest extends TestCase
         );
     }
 
-    public function testOverrideWithBeforeResolveEvent()
-    {
-        $eventsDispatcher = $this->createMock(Dispatcher::class);
-        $eventsDispatcher
-            ->expects($this->exactly(2))
-            ->method('fire')
-            ->will($this->onConsecutiveCalls('Hello Override!', null));
-        $this->translator->setEventDispatcher($eventsDispatcher);
-
-        $this->assertEquals('Hello Override!', $this->translator->get('lang.test.hello_override'));
-        $this->assertEquals('Hello Winter!', $this->translator->get('lang.test.hello_winter'));
-    }
-
     public function testNamespaceAliasing()
     {
         $this->translator->registerNamespaceAlias('winter.test', 'winter.alias');

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -184,6 +184,31 @@ class TranslatorTest extends TestCase
         $this->assertEquals('Welcome to Winter!', $translator->get('winter.test::lang.test.welcome_to_winter'));
     }
 
+    public function testSetMethodCanOverwriteAnEntireGroupForALocale()
+    {
+        $this->translator->set('winter.test::lang', [
+            'test' => [
+                'hello_winter' => 'Sup Winter?',
+                'welcome_to_winter' => 'It\'s time for Winter!',
+                'winter' => [
+                    'simplicity' => 'Fully simple',
+                    'stability' => 'Fully stable',
+                ],
+            ],
+        ], 'en_BT');
+
+        $this->translator->setLocale('en_BT');
+
+        $this->assertEquals('Sup Winter?', $this->translator->get('winter.test::lang.test.hello_winter'));
+        $this->assertEquals('It\'s time for Winter!', $this->translator->get('winter.test::lang.test.welcome_to_winter'));
+        $this->assertEquals('Fully simple', $this->translator->get('winter.test::lang.test.winter.simplicity'));
+        $this->assertEquals('Fully stable', $this->translator->get('winter.test::lang.test.winter.stability'));
+
+        // Shouldn't be changed
+        $this->assertEquals('Speed', $this->translator->get('winter.test::lang.test.winter.speed'));
+        $this->assertEquals('Security', $this->translator->get('winter.test::lang.test.winter.security'));
+    }
+
     public function testChoiceMethodProperlyLoadsAndRetrievesItem()
     {
         $t = $this->getMockBuilder(Translator::class)->onlyMethods(['get'])->setConstructorArgs([$this->getLoader(), 'en'])->getMock();

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -207,6 +207,17 @@ class TranslatorTest extends TestCase
         // Shouldn't be changed
         $this->assertEquals('Speed', $this->translator->get('winter.test::lang.test.winter.speed'));
         $this->assertEquals('Security', $this->translator->get('winter.test::lang.test.winter.security'));
+
+        $this->translator->setLocale('en');
+
+        $this->assertEquals('Hello Winter!', $this->translator->get('winter.test::lang.test.hello_winter'));
+        $this->assertEquals('Welcome to Winter!', $this->translator->get('winter.test::lang.test.welcome_to_winter'));
+        $this->assertEquals('Simplicity', $this->translator->get('winter.test::lang.test.winter.simplicity'));
+        $this->assertEquals('Stability', $this->translator->get('winter.test::lang.test.winter.stability'));
+
+        // Shouldn't be changed
+        $this->assertEquals('Speed', $this->translator->get('winter.test::lang.test.winter.speed'));
+        $this->assertEquals('Security', $this->translator->get('winter.test::lang.test.winter.security'));
     }
 
     public function testChoiceMethodProperlyLoadsAndRetrievesItem()

--- a/tests/fixtures/lang/en-gb/lang.php
+++ b/tests/fixtures/lang/en-gb/lang.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'test' => [
+        'mother' => 'mum|mums',
+    ],
+];

--- a/tests/fixtures/lang/en/lang.php
+++ b/tests/fixtures/lang/en/lang.php
@@ -5,6 +5,7 @@ return [
         'pagination' => 'Displayed records: :from-:to of :total',
         'hello_winter' => 'Hello Winter!',
         'choice' => 'Page|Pages',
+        'mother' => 'mom|moms',
     ],
     'validation' => [
         'fail' => 'Translated fallback message',

--- a/tests/fixtures/lang/en/lang.php
+++ b/tests/fixtures/lang/en/lang.php
@@ -4,6 +4,7 @@ return [
     'test' => [
         'pagination' => 'Displayed records: :from-:to of :total',
         'hello_winter' => 'Hello Winter!',
+        'welcome_to_winter' => 'Welcome to Winter!',
         'choice' => 'Page|Pages',
         'mother' => 'mom|moms',
     ],

--- a/tests/fixtures/lang/en/lang.php
+++ b/tests/fixtures/lang/en/lang.php
@@ -5,6 +5,12 @@ return [
         'pagination' => 'Displayed records: :from-:to of :total',
         'hello_winter' => 'Hello Winter!',
         'welcome_to_winter' => 'Welcome to Winter!',
+        'winter' => [
+            'simplicity' => 'Simplicity',
+            'speed' => 'Speed',
+            'stability' => 'Stability',
+            'security' => 'Security',
+        ],
         'choice' => 'Page|Pages',
         'mother' => 'mom|moms',
     ],


### PR DESCRIPTION
Refactors the "get" override to use the base "get" method for the most part, removes the "choice" method override and adds the "set" method in Translator.

Changes to the FileLoader will allow our original fix for the sublocales in the "choice" method to work even with the base Laravel functionality.

The FileLoader will now attempt to find locales in the format "xx_XX" as per the original Laravel functionality and then also attempt "xx-xx" as per the traditional usage in Winter.

Fixes https://github.com/wintercms/winter/issues/480