### PR TITLE
Add is_regex validator rule

### DIFF
--- a/src/Validation/Validator.php
+++ b/src/Validation/Validator.php
@@ -1,5 +1,7 @@
 <?php namespace Winter\Storm\Validation;
 
+use Throwable;
+
 use Illuminate\Validation\Validator as BaseValidator;
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 
@@ -40,5 +42,16 @@ class Validator extends BaseValidator implements ValidatorContract
                 ));
             }
         }
+    }
+
+    protected function validateIsRegex($attribute, $value, $rule)
+    {
+        try {
+            preg_match($value, '');
+        } catch (Throwable $e) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/Validation/IsRegexValidationTest.php
+++ b/tests/Validation/IsRegexValidationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Filesystem\Filesystem;
+use Winter\Storm\Translation\FileLoader;
+use Winter\Storm\Translation\Translator;
+use Winter\Storm\Validation\Factory;
+
+class IsRegexValidationTest extends TestCase
+{
+    /**
+     * @var Factory
+     */
+    protected $validation;
+
+    /**
+     * @var Translator
+     */
+    protected $translator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $path       = __DIR__ . '/../fixtures/lang';
+        $fileLoader = new FileLoader(new Filesystem(), $path);
+        $translator = new Translator($fileLoader, 'en');
+        $this->translator = $translator;
+
+        $this->validation = new Factory($this->translator, null);
+    }
+
+    // This validation should fail, as per Laravel pre-5.8, as well as current expected Winter functionality.
+    public function testIsRegexRule()
+    {
+        $validator = $this->validation->make([
+            'test_regex' => '/this is not a valid regex (.+)?#',
+        ], [
+            'test_regex' => 'is_regex'
+        ]);
+
+        $this->assertTrue($validator->fails());
+
+        $validator = $this->validation->make([
+            'test_regex' => '#this is a valid regex (.+)?#',
+        ], [
+            'test_regex' => 'is_regex'
+        ]);
+
+        $this->assertFalse($validator->fails());
+    }
+}


### PR DESCRIPTION
credit @jaxwilko for this nice implementation.

used in `wn-redirect-plugin` to validate the regex in the Redirect model.
ref. https://github.com/wintercms/wn-redirect-plugin/blob/main/models/Redirect.php#L179