### PR TITLE
Add withoutChildren scope to NestedTree

### DIFF
--- a/src/Database/Traits/NestedTree.php
+++ b/src/Database/Traits/NestedTree.php
@@ -440,6 +440,22 @@ trait NestedTree
 
         return $includeSelf ? $query : $query->withoutSelf();
     }
+    
+    /**
+     * Extracts all children & nested children from current query expression.
+     *
+     * @param \Illuminate\Database\Query\Builder $query
+     * @return \Illuminate\Database\Query\Builder
+     */
+    public function scopeWithoutChildren($query, $includeSelf = false)
+    {
+        $query->whereNot([
+            [$this->getLeftColumnName(), '>', $this->getLeft()],
+            [$this->getRightColumnName(), '<', $this->getRight()]
+        ]);
+
+        return $includeSelf ? $query : $query->withoutSelf();
+    }
 
     /**
      * Returns a prepared query with all parents up the tree.


### PR DESCRIPTION
Currently building a `Winter.User` blogs plugin, based on `Winter.Blog`.
I needed to list all the available parent categories for the current one, but excluding the current category's children to avoid circular references.

I thought it would be good to add this scope to the core.