### PR TITLE
Added support for creating a file object from file in storage

### DIFF
--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -159,7 +159,7 @@ class File extends Model
         $this->disk_name = $this->getDiskName();
 
         if (!$disk->copy($filePath, $this->getDiskPath())) {
-            throw new ApplicationException('Unable to move uploaded file');
+            throw new ApplicationException(sprintf('Unable to copy `%s` to `%s`', $filePath, $this->getDiskPath()));
         }
 
         return $this;

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -150,7 +150,7 @@ class File extends Model
         $disk = $this->getDisk();
 
         if (!$disk->exists($filePath)) {
-            throw new \InvalidArgumentException(sprintf('File `%s` not found in storage', $filePath));
+            throw new \InvalidArgumentException(sprintf('File `%s` was not found on the storage disk', $filePath));
         }
 
         $this->file_name = basename($filePath);

--- a/src/Database/Attach/File.php
+++ b/src/Database/Attach/File.php
@@ -143,7 +143,7 @@ class File extends Model
     }
 
     /**
-     * Creates a file object from a file in storage.
+     * Creates a file object from a file on the disk returned by $this->getDisk()
      */
     public function fromStorage(string $filePath): static
     {


### PR DESCRIPTION
This PR adds support for creating a file object model when the target file is stored on a remote disk.

Warning: should probably be the same disk as the relation model is configured for.

