### PR TITLE
Reverse order in checking mail config styles

### DIFF
--- a/src/Mail/MailManager.php
+++ b/src/Mail/MailManager.php
@@ -94,7 +94,7 @@ class MailManager extends BaseMailManager
     {
         // We will do the reverse of what Laravel does and check for "default" first, which is
         // populated by the Backend or the new "mail" config, before searching for the "driver"
-        // key that was present in older version of Winter.
+        // key that was present in older version of Winter (<1.2).
         return $this->app['config']['mail.default'] ?? $this->app['config']['mail.driver'];
     }
 }

--- a/src/Mail/MailManager.php
+++ b/src/Mail/MailManager.php
@@ -7,6 +7,7 @@ use Illuminate\Mail\MailManager as BaseMailManager;
  * Overrides the Laravel MailManager
  * - Replaces the Laravel Mailer class with the Winter Mailer class
  * - Fires mailer.beforeRegister & mailer.register events
+ * - Uses another method to determine old vs. new mail configs
  */
 class MailManager extends BaseMailManager
 {
@@ -71,4 +72,30 @@ class MailManager extends BaseMailManager
 
         return $mailer;
     }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getConfig(string $name)
+    {
+        // Here we will check if the "mailers" key exists and if it does, we will use that to
+        // determine the applicable config. Laravel checks if the "drivers" key exists, and while
+        // that does work for Laravel, it doesn't work in Winter when someone uses the Backend to
+        // populate mail settings, as these mail settings are populated into the "mailers" key.
+        return $this->app['config']['mail.mailers']
+            ? ($this->app['config']["mail.mailers.{$name}"] ?? $this->app['config']['mail'])
+            : $this->app['config']['mail'];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDefaultDriver()
+    {
+        // We will do the reverse of what Laravel does and check for "default" first, which is
+        // populated by the Backend or the new "mail" config, before searching for the "driver"
+        // key that was present in older version of Winter.
+        return $this->app['config']['mail.default'] ?? $this->app['config']['mail.driver'];
+    }
+
 }

--- a/src/Mail/MailManager.php
+++ b/src/Mail/MailManager.php
@@ -97,5 +97,4 @@ class MailManager extends BaseMailManager
         // key that was present in older version of Winter.
         return $this->app['config']['mail.default'] ?? $this->app['config']['mail.driver'];
     }
-
 }


### PR DESCRIPTION
Fixes https://github.com/wintercms/winter/issues/626

This reverses the order for checking mail configs by searching for the new format first, then checking for the old format.

Laravel checks old format first, then new format, which works fine for them, but doesn't work for us as we also populate settings via the Backend, which populates the settings in the new format.

There is a small gotcha here - I believe the Backend stored the config in the old format pre v1.2, which means if someone upgrades their `config/mail.php` to follow the new format, this will make the config file take precedence. Saving the settings in the Backend again will alleviate this.