### PR TITLE
Added support for including anon classes multiple times per execution

### DIFF
--- a/src/Database/Updater.php
+++ b/src/Database/Updater.php
@@ -13,6 +13,8 @@ use Winter\Storm\Database\Model;
  */
 class Updater
 {
+    protected static $migrationCache = [];
+
     /**
      * Sets up a migration or seed file.
      */
@@ -69,19 +71,26 @@ class Updater
      * @param  string  $file
      * @return object|null
      */
-    public function resolve($file)
+    public function resolve($file): ?object
     {
         if (!File::isFile($file)) {
             return null;
         }
 
+        if (isset(static::$migrationCache[$file])) {
+            return is_object(static::$migrationCache[$file])
+                ? static::$migrationCache[$file]
+                : new static::$migrationCache[$file];
+        }
+
         $instance = require_once $file;
 
         if (is_object($instance)) {
-            return $instance;
+            return static::$migrationCache[$file] = $instance;
         }
+
         if ($class = $this->getClassFromFile($file)) {
-            return new $class;
+            return new (static::$migrationCache[$file] = $class);
         }
     }
 

--- a/src/Database/Updater.php
+++ b/src/Database/Updater.php
@@ -13,6 +13,9 @@ use Winter\Storm\Database\Model;
  */
 class Updater
 {
+    /**
+     * @var array Local cache of migration file paths to support anonymous migrations [$path => $anonInstance || $className]
+     */
     protected static $migrationCache = [];
 
     /**


### PR DESCRIPTION
`require_once` will fail to load anon classes on subsequent requests. This patch adds a caching layer that allows included classes and object to he held in memory and returned as needed