### PR TITLE
Make extend() method usable with behaviors.

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -147,7 +147,7 @@ class Model extends EloquentModel implements ModelInterface
     /**
      * Extend this object properties upon construction.
      */
-    public static function extend(Closure $callback, $after = false)
+    public static function extend(callable $callback, bool $after = false)
     {
         self::extendableExtendCallback($callback, $after);
     }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -147,9 +147,9 @@ class Model extends EloquentModel implements ModelInterface
     /**
      * Extend this object properties upon construction.
      */
-    public static function extend(Closure $callback)
+    public static function extend(Closure $callback, $after = false)
     {
-        self::extendableExtendCallback($callback);
+        self::extendableExtendCallback($callback, $after);
     }
 
     /**

--- a/src/Extension/Extendable.php
+++ b/src/Extension/Extendable.php
@@ -50,7 +50,7 @@ class Extendable
         return self::extendableCallStatic($name, $params);
     }
 
-    public static function extend(callable $callback, $after = false)
+    public static function extend(callable $callback, bool $after = false)
     {
         self::extendableExtendCallback($callback, $after);
     }

--- a/src/Extension/Extendable.php
+++ b/src/Extension/Extendable.php
@@ -50,8 +50,8 @@ class Extendable
         return self::extendableCallStatic($name, $params);
     }
 
-    public static function extend(callable $callback)
+    public static function extend(callable $callback, $after = false)
     {
-        self::extendableExtendCallback($callback);
+        self::extendableExtendCallback($callback, $after);
     }
 }

--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -187,7 +187,7 @@ trait ExtendableTrait
     /**
      * Programmatically adds a method to the extendable class.
      */
-    public function addDynamicMethod(string $name, callable $method, ?string $extension = null): void
+    public function addDynamicMethod(string $name, callable|string $method, ?string $extension = null): void
     {
         if (
             is_string($method) &&

--- a/tests/Extension/ExtendableTest.php
+++ b/tests/Extension/ExtendableTest.php
@@ -39,6 +39,26 @@ class ExtendableTest extends TestCase
         $this->assertEquals('bar', $subject->classAttribute);
     }
 
+    public function testExtendingExtendableClassAfterBehaviors()
+    {
+        // test default behavior
+        ExtendableTestExampleExtendableClass::extend(function ($extension) {
+            $this->assertFalse($extension->methodExists('getFoo'));
+        });
+
+        // test with after explicitly set to false
+        ExtendableTestExampleExtendableClass::extend(function ($extension) {
+            $this->assertFalse($extension->methodExists('getFoo'));
+        }, after: false);
+
+        // test with after set to true
+        ExtendableTestExampleExtendableClass::extend(function ($extension) {
+            $this->assertTrue($extension->methodExists('getFoo'));
+        }, after: true);
+
+        $instance = new ExtendableTestExampleExtendableClass;
+    }
+
     public function testSettingDeclaredPropertyOnClass()
     {
         $subject = $this->mockClassLoader(ExtendableTestExampleExtendableClass::class);


### PR DESCRIPTION
Replaces #112 

```php
Model::extend(function ($model) {
    $model->behaviorMethodAvailable();
}, after: true);
```

Related: https://github.com/wintercms/docs/pull/98