### PR TITLE
Slug generation performance improvement

### DIFF
--- a/src/Database/Traits/Sluggable.php
+++ b/src/Database/Traits/Sluggable.php
@@ -95,8 +95,8 @@ trait Sluggable
         $separator = $this->getSluggableSeparator();
         $_value = $value;
         while (($this->methodExists('withTrashed') && $this->allowTrashedSlugs) ?
-            $this->newSluggableQuery()->where($name, $_value)->withTrashed()->count() > 0 :
-            $this->newSluggableQuery()->where($name, $_value)->count() > 0
+            $this->newSluggableQuery()->where($name, $_value)->withTrashed()->exists() :
+            $this->newSluggableQuery()->where($name, $_value)->exists()
         ) {
             $counter++;
             $_value = $value . $separator . $counter;


### PR DESCRIPTION
The `EXISTS` sql statement will return true at the first existing value where the `COUNT` will uselessly continue to loop through the whole table which is inaccurate for this use case.

The syntax is more readable too IMO.