### PR TITLE
Readability improvement for Slug trait

### DIFF
--- a/src/Database/Traits/Sluggable.php
+++ b/src/Database/Traits/Sluggable.php
@@ -94,10 +94,8 @@ trait Sluggable
         $counter = 1;
         $separator = $this->getSluggableSeparator();
         $_value = $value;
-        while (($this->methodExists('withTrashed') && $this->allowTrashedSlugs) ?
-            $this->newSluggableQuery()->where($name, $_value)->withTrashed()->count() > 0 :
-            $this->newSluggableQuery()->where($name, $_value)->count() > 0
-        ) {
+
+        while ($this->newSluggableQuery()->where($name, $_value)->count() > 0) {
             $counter++;
             $_value = $value . $separator . $counter;
         }
@@ -107,13 +105,22 @@ trait Sluggable
 
     /**
      * Returns a query that excludes the current record if it exists
+     * Supports SoftDelete trait
      * @return Builder
      */
     protected function newSluggableQuery()
     {
-        return $this->exists
-            ? $this->newQuery()->where($this->getKeyName(), '<>', $this->getKey())
-            : $this->newQuery();
+        $query = $this->newQuery();
+
+        if ($this->exists) {
+            $query->where($this->getKeyName(), '<>', $this->getKey());
+        }
+
+        if ($this->methodExists('withTrashed') && $this->allowTrashedSlugs) {
+            $query->withTrashed();
+        }
+
+        return $query;
     }
 
     /**

--- a/src/Database/Traits/Sluggable.php
+++ b/src/Database/Traits/Sluggable.php
@@ -94,7 +94,7 @@ trait Sluggable
         $counter = 1;
         $separator = $this->getSluggableSeparator();
         $_value = $value;
-        while ($this->newSluggableQuery()->where($name, $_value)->count() > 0) {
+        while ($this->newSluggableQuery()->where($name, $_value)->exists()) {
             $counter++;
             $_value = $value . $separator . $counter;
         }


### PR DESCRIPTION
This PR moves the `SoftDelete` support from `getSluggableUniqueAttributeValue` to `newSluggableQuery` which is its place IMO and improve the readability in the slug generation while loop.

Will conflict with #118