### PR TITLE
Added fix to allow pivots to use classes on attach

### DIFF
--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -326,6 +326,11 @@ trait HasRelationships
             case 'belongsToMany':
                 $relation = $this->validateRelationArgs($relationName, ['table', 'key', 'otherKey', 'parentKey', 'relatedKey', 'pivot', 'timestamps']);
                 $relationObj = $this->$relationType($relation[0], $relation['table'], $relation['key'], $relation['otherKey'], $relation['parentKey'], $relation['relatedKey'], $relationName);
+
+                if (isset($relation['pivotModel'])) {
+                    $relationObj->using($relation['pivotModel']);
+                }
+
                 break;
 
             case 'morphTo':


### PR DESCRIPTION
This PR ports some functionality from Laravel to allow for pivot models to be used during an attach call.

This means that events can now be processed on pivot models during the attach process.