### PR TITLE
Fix hidden file glob on systems without GLOB_BRACE support

### DIFF
--- a/src/Filesystem/Zip.php
+++ b/src/Filesystem/Zip.php
@@ -152,7 +152,19 @@ class Zip extends ZipArchive
             $folders = [];
             $recursive = false;
         } else {
-            $files = glob($source, GLOB_BRACE);
+            // Workaround for systems that do not support GLOB_BRACE (ie. Solaris, Alpine Linux)
+            if (!defined('GLOB_BRACE') && $includeHidden) {
+                $files = array_merge(
+                    glob(dirname($source) . '/*'),
+                    glob(dirname($source) . '/.[!.]*'),
+                    glob(dirname($source) . '/..?*')
+                );
+            } elseif (defined('GLOB_BRACE')) {
+                $files = glob($source, GLOB_BRACE);
+            } else {
+                $files = glob($source);
+            }
+
             $folders = glob(dirname($source) . '/*', GLOB_ONLYDIR);
         }
 


### PR DESCRIPTION
Fixes https://github.com/wintercms/winter/issues/714

Allows systems without `GLOB_BRACE` support (ie. Solaris, Alpine Linux) to still correctly include hidden files in a Zip by emulating the brace search using multiple `glob` passes.