### PR TITLE
Fix eventArgs not being merged correctly for BelongsOrMorphToMany relations

### DIFF
--- a/src/Database/Relations/Concerns/BelongsOrMorphsToMany.php
+++ b/src/Database/Relations/Concerns/BelongsOrMorphsToMany.php
@@ -125,9 +125,9 @@ trait BelongsOrMorphsToMany
         $eventArgs = [$this->relationName];
 
         if ($this->using) {
-            $eventArgs += [$id, $attributes];
+            $eventArgs = [...$eventArgs, $id, $attributes];
         } else {
-            $eventArgs += [$attachedIdList, $insertData];
+            $eventArgs = [...$eventArgs, $attachedIdList, $insertData];
         }
 
         /**


### PR DESCRIPTION
This PR fixes an issue introduced when PR #120 was merged and fixes the issue where the `eventArgs` are not being properly merged.

This comment also explains the issue using the `+` operator with non-associative arrays: https://github.com/wintercms/storm/pull/120#issuecomment-1267072421