### PR TITLE
Fixed bug when dynamically adding hasMany* relations

### DIFF
--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -949,7 +949,7 @@ trait HasRelationships
      */
     public function addHasOneThroughRelation(string $name, array $config): void
     {
-        $this->addRelation('HasOneThrough', $name, $config);
+        $this->addRelation('hasOneThrough', $name, $config);
     }
 
     /**
@@ -959,7 +959,7 @@ trait HasRelationships
      */
     public function addHasManyThroughRelation(string $name, array $config): void
     {
-        $this->addRelation('HasManyThrough', $name, $config);
+        $this->addRelation('hasManyThrough', $name, $config);
     }
 
     /**


### PR DESCRIPTION
The relation type key was being passed as upper camel where `addRelation` is expecting lower camel