### PR TITLE
Patch alert method to keep compatibility with Laravel

### DIFF
--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -35,9 +35,10 @@ abstract class Command extends BaseCommand implements SignalableCommandInterface
      * Write a string in an alert box.
      *
      * @param  string  $string
+     * @param  int|string|null  $verbosity
      * @return void
      */
-    public function alert($string)
+    public function alert($string, $verbosity = null)
     {
         $maxLength = 80;
         $padding = 5;

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -61,7 +61,7 @@ abstract class Command extends BaseCommand implements SignalableCommandInterface
         $width = $innerLineWidth + ($border * 2);
 
         // Top border
-        $this->comment(str_repeat('*', $width));
+        $this->comment(str_repeat('*', $width), $verbosity);
 
         // Alert content
         foreach ($lines as $line) {
@@ -69,12 +69,13 @@ abstract class Command extends BaseCommand implements SignalableCommandInterface
             $this->comment(
                 str_repeat('*', $border)
                 . str_pad($line, $innerLineWidth, ' ', STR_PAD_BOTH)
-                . str_repeat('*', $border)
+                . str_repeat('*', $border),
+                $verbosity
             );
         }
 
         // Bottom border
-        $this->comment(str_repeat('*', $width));
+        $this->comment(str_repeat('*', $width), $verbosity);
 
         $this->newLine();
     }


### PR DESCRIPTION
Laravel just released `v9.36` which includes this PR: https://github.com/laravel/framework/pull/44614

The PR adds a `verbosity` param to the command `alert()` method, this causes us the issue:

```
Fatal error: Declaration of Winter\Storm\Console\Command::alert($string) must be compatible with Illuminate\Console\Command::alert($string, $verbosity = null)
```

This PR adds the param to ensure we are compatible with the upstream