### PR TITLE
Refactor the Singleton trait to bind to the application container

### DIFF
--- a/src/Support/Traits/Singleton.php
+++ b/src/Support/Traits/Singleton.php
@@ -1,35 +1,47 @@
 <?php namespace Winter\Storm\Support\Traits;
 
+use Illuminate\Contracts\Container\Container;
+
 /**
  * Singleton trait.
  *
  * Allows a simple interface for treating a class as a singleton.
  * Usage: myObject::instance()
  *
- * @author Alexey Bobkov, Samuel Georges
+ * @author Alexey Bobkov, Samuel Georges, Luke Towers
  */
 trait Singleton
 {
-    protected static $instance;
-
     /**
      * Create a new instance of this singleton.
-     *
-     * @return static
      */
-    final public static function instance()
+    final public static function instance(?Container $container = null): static
     {
-        return isset(static::$instance)
-            ? static::$instance
-            : static::$instance = new static;
+        if (!$container) {
+            $container = app();
+        }
+
+        if (!$container->bound(static::class)) {
+            $container->singleton(static::class, function () {
+                return new static;
+            });
+        }
+
+        return $container->make(static::class);
     }
 
     /**
      * Forget this singleton's instance if it exists
      */
-    final public static function forgetInstance()
+    final public static function forgetInstance(?Container $container = null): void
     {
-        static::$instance = null;
+        if (!$container) {
+            $container = app();
+        }
+
+        if ($container->bound(static::class)) {
+            $container->forgetInstance(static::class);
+        }
     }
 
     /**


### PR DESCRIPTION
Refactors the Singleton trait to bind to the application container instead of the global scope. 

This fixes several issues that surface when attempting to run the application within itself or multiple times in a single long running PHP process, both of which occur under advanced deployment environments like Laravel Vapor or Octane.