### PR TITLE
Prioritize local dynamic methods over behavior-provided methods

### DIFF
--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -424,7 +424,9 @@ trait ExtendableTrait
     }
 
     /**
-     * Magic method for `__call()`. Priority is as follows:
+     * Magic method for `__call()`.
+     *
+     * Callback priority is as follows:
      * - "Dynamic Methods" added locally to the object via addDynamicMethod($name, $callable)
      * - Methods available on Behaviors that have been implemented by the object
      * - Pass it to the parent's __call() method if it defines one


### PR DESCRIPTION
This prioritizes locally added dynamic methods over public methods that have been defined in behaviors that are implemented on the object.