### PR TITLE
Ensure that getAvailablePaths respects the maxDepth of the file iterator

### DIFF
--- a/src/Halcyon/Datasource/FileDatasource.php
+++ b/src/Halcyon/Datasource/FileDatasource.php
@@ -36,8 +36,6 @@ class FileDatasource extends Datasource
 
     /**
      * The maximum depth of the filesystem to scan, defaulting to 1 subdirectory.
-     *
-     * @var int
      */
     protected int $maxDepth = 1;
 

--- a/src/Halcyon/Datasource/FileDatasource.php
+++ b/src/Halcyon/Datasource/FileDatasource.php
@@ -35,6 +35,13 @@ class FileDatasource extends Datasource
     protected $resolvedBasePaths = [];
 
     /**
+     * The maximum depth of the filesystem to scan, defaulting to 1 subdirectory.
+     *
+     * @var int
+     */
+    protected int $maxDepth = 1;
+
+    /**
      * Create a new datasource instance.
      *
      * @param string $basePath
@@ -98,7 +105,7 @@ class FileDatasource extends Datasource
         }
 
         $it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dirPath));
-        $it->setMaxDepth(1); // Support only a single level of subdirectories
+        $it->setMaxDepth($this->maxDepth);
         $it->rewind();
 
         while ($it->valid()) {
@@ -336,6 +343,10 @@ class FileDatasource extends Datasource
         $it = (is_dir($this->basePath))
             ? new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->basePath))
             : [];
+
+        if (!is_array($it)) {
+            $it->setMaxDepth($this->maxDepth + 1);
+        }
 
         foreach ($it as $file) {
             if ($file->isDir()) {


### PR DESCRIPTION
This PR fixes an issue brought to light by https://github.com/wintercms/winter/pull/791. 

When `FileDatasource::getAvailablePaths()` is called, it does not respect the same maxDepth setting that is set in `FileDatasource::select()` meaning that the reported paths differ from the selectable paths.

This PR adds the `setMaxDepth()` call on the iterator used in `getAvailablePaths()` and sets a property for `maxDepth` to remove magic numbers and allow for custom extensions. 