### PR TITLE
Improve ClassLoader support on Windows

### DIFF
--- a/src/Support/ClassLoader.php
+++ b/src/Support/ClassLoader.php
@@ -158,7 +158,7 @@ class ClassLoader
      */
     protected function resolvePath(string $path): string
     {
-        if (!Str::startsWith($path, ['/', '\\'])) {
+        if (!Str::startsWith($path, ['/', '\\', $this->basePath . DIRECTORY_SEPARATOR])) {
             $path = $this->basePath . DIRECTORY_SEPARATOR . $path;
         }
         return $path;


### PR DESCRIPTION
On windows the basePath does not necessarily start with a slash or backslash.

See : https://github.com/wintercms/storm/pull/72#issuecomment-1359729709