### PR TITLE
Prefer caching the relative path to a class in the ClassLoader

### DIFF
--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -124,6 +124,21 @@ class Filesystem extends FilesystemBase
     }
 
     /**
+     * Returns whether the file path is an absolute path.
+     * @see Symfony\Component\Filesystem\Filesystem::isAbsolutePath()
+     */
+    public function isAbsolutePath(string $file): bool
+    {
+        return '' !== $file && (strspn($file, '/\\', 0, 1)
+            || (\strlen($file) > 3 && ctype_alpha($file[0])
+                && ':' === $file[1]
+                && strspn($file, '/\\', 2, 1)
+            )
+            || null !== parse_url($file, \PHP_URL_SCHEME)
+        );
+    }
+
+    /**
      * Determines if the given path is a local path.
      *
      * Returns `true` if the path is local, `false` otherwise.
@@ -231,7 +246,7 @@ class Filesystem extends FilesystemBase
      * @param string $path
      * @param string $contents
      * @param bool|int $lock
-     * @return bool|int
+     * @return int|false
      */
     public function put($path, $contents, $lock = false)
     {

--- a/src/Support/ClassLoader.php
+++ b/src/Support/ClassLoader.php
@@ -158,7 +158,7 @@ class ClassLoader
      */
     protected function resolvePath(string $path): string
     {
-        if (!Str::startsWith($path, ['/', '\\', $this->basePath . DIRECTORY_SEPARATOR])) {
+        if (!$this->files->isAbsolutePath($path)) {
             $path = $this->basePath . DIRECTORY_SEPARATOR . $path;
         }
         return $path;
@@ -228,10 +228,17 @@ class ClassLoader
 
     /**
      * Add a namespace prefix to the autoloader
+     *
+     * @param string $namespacePrefix The namespace prefix for this package
+     * @param string $path The path to this package, either relative to the base path or absolute
      */
-    public function autoloadPackage(string $namespacePrefix, string $relativePath): void
+    public function autoloadPackage(string $namespacePrefix, string $path): void
     {
-        $this->autoloadedPackages[ltrim(Str::lower($namespacePrefix), '\\')] = $relativePath;
+        // Normalize the path to an absolute path and then attempt to use the relative path
+        // if the path is contained within the basePath
+        $path = Str::after($this->resolvePath($path), $this->basePath . DIRECTORY_SEPARATOR);
+
+        $this->autoloadedPackages[ltrim(Str::lower($namespacePrefix), '\\')] = $path;
 
         // Ensure packages are sorted by length of the prefix to prevent a greedier prefix
         // from being matched first when attempting to autoload a class

--- a/tests/Filesystem/FilesystemTest.php
+++ b/tests/Filesystem/FilesystemTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Winter\Storm\Filesystem\Filesystem;
+
+/**
+ *
+ */
+class FilesystemTest extends TestCase
+{
+    protected ?Filesystem $filesystem = null;
+
+    public function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+    }
+
+    /**
+     * @dataProvider providePathsForIsAbsolutePath
+     * @see Symfony\Component\Filesystem\Tests\FilesystemTest::testIsAbsolutePath
+     */
+    public function testIsAbsolutePath($path, $expectedResult)
+    {
+        $result = $this->filesystem->isAbsolutePath($path);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function providePathsForIsAbsolutePath()
+    {
+        return [
+            ['/var/lib', true],
+            ['c:\\\\var\\lib', true],
+            ['\\var\\lib', true],
+            ['var/lib', false],
+            ['../var/lib', false],
+            ['', false],
+        ];
+    }
+}


### PR DESCRIPTION
Adds Filesystem->isAbsolutePath() and changes the ClassLoader->autoloadPackage() logic to prefer storing a relative path to a class file over an absolute one.

This solves an issue that occurs when deploying using an atomic deployment strategy on a server where the storage folder is shared between deployments. 