### PR TITLE
Fix missing attributes in FormBuilder inputs

### DIFF
--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -30,7 +30,7 @@ class FormBuilder
     /**
      * The session store implementation.
      */
-    protected ?\Illuminate\Session\Store $session;
+    protected ?\Illuminate\Session\Store $session = null;
 
     /**
      * The current model instance for the form.
@@ -228,9 +228,9 @@ class FormBuilder
     {
         $token = !empty($this->csrfToken)
             ? $this->csrfToken
-            : $this->session->token();
+            : ($this->session?->token() ?? null);
 
-        return $this->hidden('_token', $token);
+        return ($token) ? $this->hidden('_token', $token) : '';
     }
 
     /**
@@ -270,29 +270,28 @@ class FormBuilder
             $options['name'] = $name;
         }
 
+        $merge = [
+            'type' => $type,
+        ];
+
         if (!empty($name)) {
             // We will get the appropriate value for the given field. We will look for the
             // value in the session for the value in the old input data then we'll look
             // in the model instance if one is set. Otherwise we will just use empty.
-            $id = $this->getIdAttribute($name, $options);
+            $merge['id'] = $this->getIdAttribute($name, $options);
 
-            if (!in_array($type, $this->skipValueTypes)) {
-                $value = $this->getValueAttribute($name, $value);
-            }
-
-            // Once we have the type, value, and ID we can merge them into the rest of the
-            // attributes array so we can convert them into their HTML attribute format
-            // when creating the HTML element. Then, we will return the entire input.
-            $merge = compact('type', 'value', 'id');
-
-            if ($id === "") {
+            if ($merge['id'] === "") {
                 unset($merge['id']);
             }
-
-            $options = array_filter(array_merge($options, $merge), function ($item) {
-                return !is_null($item);
-            });
         }
+
+        if (!in_array($type, $this->skipValueTypes)) {
+            $merge['value'] = $this->getValueAttribute($name, $value);
+        }
+
+        $options = array_filter(array_merge($options, $merge), function ($item) {
+            return (!is_null($item) && $item !== false);
+        });
 
         return '<input' . $this->html->attributes($options) . '>';
     }
@@ -849,11 +848,11 @@ class FormBuilder
     /**
      * Get the value that should be assigned to the field.
      *
-     * @param  string  $name
-     * @param  string|array  $value
+     * @param  string|null  $name
+     * @param  string|array|int|null  $value
      * @return string|array|null
      */
-    public function getValueAttribute($name, $value = null)
+    public function getValueAttribute(?string $name = null, $value = null)
     {
         if (empty($name)) {
             return $value;

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -279,10 +279,6 @@ class FormBuilder
             // value in the session for the value in the old input data then we'll look
             // in the model instance if one is set. Otherwise we will just use empty.
             $merge['id'] = $this->getIdAttribute($name, $options);
-
-            if ($merge['id'] === "") {
-                unset($merge['id']);
-            }
         }
 
         if (!in_array($type, $this->skipValueTypes)) {
@@ -830,7 +826,7 @@ class FormBuilder
      *
      * @param  string  $name
      * @param  array   $attributes
-     * @return string
+     * @return string|null
      */
     public function getIdAttribute($name, $attributes)
     {
@@ -842,7 +838,7 @@ class FormBuilder
             return $name;
         }
 
-        return '';
+        return null;
     }
 
     /**

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Request;
 use Winter\Storm\Support\Collection;
 
 require_once("helpers-array.php");

--- a/tests/Assertions/AssertHtml.php
+++ b/tests/Assertions/AssertHtml.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Winter\Storm\Tests\Assertions;
+
+use DOMElement;
+use PHPUnit\Framework\Assert;
+
+trait AssertHtml
+{
+    public function assertElementIs($expected, $html, $message = '')
+    {
+        $constraint = Assert::callback(function ($expected) use ($html) {
+            $element = $this->parseElement($html);
+
+            return strtolower($element->tagName) === strtolower($expected);
+        });
+
+        Assert::assertThat($expected, $constraint, $message ?: 'Failed asserting that HTML is a "' . $expected . '" tag.');
+    }
+
+    public function assertElementHasAttribute($attribute, $html, $message = '')
+    {
+        Assert::assertTrue(
+            $this->elementHasAttribute($attribute, $html),
+            $message ?: 'Failed asserting that HTML contains attribute "' . $attribute . '".'
+        );
+    }
+
+    public function assertElementDoesntHaveAttribute($attribute, $html, $message = '')
+    {
+        Assert::assertFalse(
+            $this->elementHasAttribute($attribute, $html),
+            $message ?: 'Failed asserting that HTML does not contain attribute "' . $attribute . '".'
+        );
+    }
+
+    public function assertElementAttributeEquals($attribute, $expected, $html, $message = '')
+    {
+        $constraint = Assert::callback(function ($expected) use ($attribute, $html) {
+            $element = $this->parseElement($html);
+
+            if (!$element->hasAttribute($attribute)) {
+                Assert::fail('HTML attribute "' . $attribute . '" does not exist');
+            }
+
+            return $element->getAttribute($attribute) === $expected;
+        });
+
+        Assert::assertThat($expected, $constraint, $message ?: 'Failed asserting that attribute "' . $attribute . '" equals "' . $expected . '".');
+    }
+
+    public function assertElementAttributeNotEquals($attribute, $expected, $html, $message = '')
+    {
+        $constraint = Assert::callback(function ($expected) use ($attribute, $html) {
+            $element = $this->parseElement($html);
+
+            if (!$element->hasAttribute($attribute)) {
+                Assert::fail('HTML attribute "' . $attribute . '" does not exist');
+            }
+
+            return $element->getAttribute($attribute) !== $expected;
+        });
+
+        Assert::assertThat($expected, $constraint, $message ?: 'Failed asserting that attribute "' . $attribute . '" does not equal "' . $expected . '".');
+    }
+
+    public function assertElementContainsText($expected, $html, $message = '')
+    {
+        $constraint = Assert::callback(function ($expected) use ($html) {
+            $element = $this->parseElement($html);
+
+            return trim($element->textContent) === trim($expected);
+        });
+
+        Assert::assertThat($expected, $constraint, $message ?: 'Failed asserting that HTML element contains the text "' . $expected . '".');
+    }
+
+    public function assertElementDoesntContainText($expected, $html, $message = '')
+    {
+        $constraint = Assert::callback(function ($expected) use ($html) {
+            $element = $this->parseElement($html);
+
+            return trim($element->textContent) !== trim($expected);
+        });
+
+        Assert::assertThat($expected, $constraint, $message ?: 'Failed asserting that HTML element does not contain the text "' . $expected . '".');
+    }
+
+    protected function elementHasAttribute($attribute, $html)
+    {
+        $element = $this->parseElement($html);
+
+        return $element->hasAttribute($attribute);
+    }
+
+    protected function parseElement($html): DOMElement
+    {
+        libxml_use_internal_errors(true);
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+
+        // Ensure HTML is read as UTF-8
+        $dom->loadHTML('<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body>' . $html . '</body></html>');
+
+        $body = $dom->getElementsByTagName('body');
+        $body = $body->item(0);
+
+        if ($body->childNodes->length > 1) {
+            Assert::fail('HTML contains more than one HTML element.');
+        }
+
+        return $body->childNodes->item(0);
+    }
+}

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -232,6 +232,16 @@ class FormBuilderTest extends TestCase
         $this->assertElementAttributeEquals('value', 'my value', $result);
     }
 
+    public function testFormInputBooleanAttribute()
+    {
+        $result = $this->formBuilder->input(type: 'text', name: 'my-name', value: 'my value', options: ['required']);
+
+        $this->assertElementIs('input', $result);
+        $this->assertElementAttributeEquals('name', 'my-name', $result);
+        $this->assertElementAttributeEquals('type', 'text', $result);
+        $this->assertElementHasAttribute('required', $result);
+    }
+
     /**
      * @testdox can create a text input of type "email".
      */

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -6,11 +6,25 @@ use Winter\Storm\Router\UrlGenerator;
 
 use Illuminate\Http\Request;
 use Illuminate\Routing\RouteCollection;
+use Winter\Storm\Tests\Assertions\AssertHtml;
 
+/**
+ * @testdox The FormBuilder utility
+ * @covers \Winter\Storm\Html\FormBuilder
+ */
 class FormBuilderTest extends TestCase
 {
+    use AssertHtml;
+
+    /**
+     * FormBuilder instance.
+     */
+    protected FormBuilder $formBuilder;
+
     public function setUp() : void
     {
+        parent::setUp();
+
         $htmlBuilder = new HtmlBuilder;
         $generator = new UrlGenerator(
             new RouteCollection,
@@ -19,40 +33,280 @@ class FormBuilderTest extends TestCase
         $this->formBuilder = new FormBuilder($htmlBuilder, $generator);
     }
 
-    public function testInputIdMissing()
+    /**
+     * @testdox can generate a form open tag.
+     */
+    public function testFormOpen()
     {
-        $result = $this->formBuilder->input(type:"text", name:"my-name", value:"my value");
-        $this->assertEquals('<input name="my-name" type="text" value="my value">', $result);
+        $result = $this->formBuilder->open();
+
+        $this->assertElementIs('form', $result);
+        $this->assertElementAttributeEquals('method', 'POST', $result);
+        $this->assertElementAttributeEquals('action', 'https://www.example.com/path', $result);
+        $this->assertElementDoesntHaveAttribute('enctype', $result);
     }
 
-    public function testInputIdEmpty()
+    /**
+     * @testdox can generate a form open tag with method "GET".
+     */
+    public function testFormOpenMethodGet()
     {
-        $result = $this->formBuilder->input(type:"text", name:"my-name", value:"my value", options:["id"=>""]);
-        $this->assertEquals('<input id="" name="my-name" type="text" value="my value">', $result);
+        $result = $this->formBuilder->open([
+            'method' => 'GET'
+        ]);
+
+        $this->assertElementIs('form', $result);
+        $this->assertElementAttributeEquals('method', 'GET', $result);
+        $this->assertElementAttributeEquals('action', 'https://www.example.com/path', $result);
+        $this->assertElementDoesntHaveAttribute('enctype', $result);
     }
 
-    public function testInputIdNull()
+    /**
+     * @testdox can generate a form open tag and accept file uploads.
+     */
+    public function testFormOpenFiles()
     {
-        $result = $this->formBuilder->input(type:"text", name:"my-name", value:"my value", options:["id"=>null]);
-        $this->assertEquals('<input name="my-name" type="text" value="my value">', $result);
+        $result = $this->formBuilder->open([
+            'files' => true,
+        ]);
+
+        $this->assertElementIs('form', $result);
+        $this->assertElementAttributeEquals('method', 'POST', $result);
+        $this->assertElementAttributeEquals('action', 'https://www.example.com/path', $result);
+        $this->assertElementAttributeEquals('enctype', 'multipart/form-data', $result);
     }
 
-    public function testInputIdFalse()
+    /**
+     * @testdox can generate a form open tag and have custom attributes.
+     */
+    public function testFormOpenCustomAttributes()
     {
-        $result = $this->formBuilder->input(type:"text", name:"my-name", value:"my value", options:["id"=>false]);
-        $this->assertEquals('<input id="" name="my-name" type="text" value="my value">', $result);
+        $result = $this->formBuilder->open([
+            'data-my-attribute' => 'my-value',
+            'class' => 'boss-form',
+        ]);
+
+        $this->assertElementIs('form', $result);
+        $this->assertElementAttributeEquals('method', 'POST', $result);
+        $this->assertElementAttributeEquals('action', 'https://www.example.com/path', $result);
+        $this->assertElementDoesntHaveAttribute('enctype', $result);
+        $this->assertElementAttributeEquals('data-my-attribute', 'my-value', $result);
+        $this->assertElementAttributeEquals('class', 'boss-form', $result);
     }
 
-    public function testInputIdZero()
+    /**
+     * @testdox can generate a form open tag with a data attribute AJAX request.
+     */
+    public function testFormAjax()
     {
-        $result = $this->formBuilder->input(type:"text", name:"my-name", value:"my value", options:["id"=>0]);
-        $this->assertEquals('<input id="0" name="my-name" type="text" value="my value">', $result);
+        $result = $this->formBuilder->ajax('onSave');
+
+        $this->assertElementIs('form', $result);
+        $this->assertElementAttributeEquals('method', 'POST', $result);
+        $this->assertElementAttributeEquals('action', 'https://www.example.com/path', $result);
+        $this->assertElementAttributeEquals('data-request', 'onSave', $result);
     }
 
-    public function testInputIdMissingWithAssociatedLabel()
+    /**
+     * @testdox can generate a form open tag with a data attribute AJAX request to a different target.
+     */
+    public function testFormAjaxTarget()
     {
-        $result = $this->formBuilder->label(name:"my-input", value:"my input label");
-        $result = $this->formBuilder->input(type:"text", name:"my-input", value:"my value");
-        $this->assertEquals('<input name="my-input" type="text" value="my value" id="my-input">', $result);
+        $result = $this->formBuilder->ajax(['myComponent', 'onSave']);
+
+        $this->assertElementIs('form', $result);
+        $this->assertElementAttributeEquals('method', 'POST', $result);
+        $this->assertElementAttributeEquals('action', 'https://www.example.com/path', $result);
+        $this->assertElementAttributeEquals('data-request', 'myComponent::onSave', $result);
+    }
+
+    /**
+     * @testdox can generate a form open tag with a data attribute AJAX request and accept files.
+     */
+    public function testFormAjaxFiles()
+    {
+        $result = $this->formBuilder->ajax('onSave', [
+            'files' => true,
+        ]);
+
+        $this->assertElementIs('form', $result);
+        $this->assertElementAttributeEquals('method', 'POST', $result);
+        $this->assertElementAttributeEquals('action', 'https://www.example.com/path', $result);
+        $this->assertElementAttributeEquals('data-request', 'onSave', $result);
+        $this->assertElementAttributeEquals('data-request-files', '1', $result);
+        $this->assertElementAttributeEquals('enctype', 'multipart/form-data', $result);
+    }
+
+    /**
+     * @testdox can generate a form close tag.
+     */
+    public function testClose()
+    {
+        $result = $this->formBuilder->close();
+
+        $this->assertEquals('</form>', $result);
+    }
+
+    /**
+     * @testdox can create a text input. The text input will not have an ID.
+     */
+    public function testFormInputText()
+    {
+        $result = $this->formBuilder->input(type: 'text', name: 'my-name', value: 'my value');
+
+        $this->assertElementIs('input', $result);
+        $this->assertElementDoesntHaveAttribute('id', $result);
+        $this->assertElementAttributeEquals('name', 'my-name', $result);
+        $this->assertElementAttributeEquals('type', 'text', $result);
+        $this->assertElementAttributeEquals('value', 'my value', $result);
+    }
+
+    /**
+     * @testdox can create a text input with a corresponding label. The text input will have an ID.
+     */
+    public function testFormInputTextWithLabel()
+    {
+        $result = $this->formBuilder->label(name: 'my-input', value: 'my input label');
+        $result = $this->formBuilder->input(type: 'text', name: 'my-input', value: 'my value');
+
+        $this->assertElementIs('input', $result);
+        $this->assertElementAttributeEquals('id', 'my-input', $result);
+        $this->assertElementAttributeEquals('name', 'my-input', $result);
+        $this->assertElementAttributeEquals('type', 'text', $result);
+        $this->assertElementAttributeEquals('value', 'my value', $result);
+    }
+
+    /**
+     * @testdox accepts an empty ID and sets the ID attribute to empty.
+     */
+    public function testFormInputTextIdEmpty()
+    {
+        $result = $this->formBuilder->input(type: 'text', name: 'my-name', value: 'my value', options: ['id' => '']);
+
+        $this->assertElementIs('input', $result);
+        $this->assertElementAttributeEquals('id', '', $result);
+        $this->assertElementAttributeEquals('name', 'my-name', $result);
+        $this->assertElementAttributeEquals('type', 'text', $result);
+        $this->assertElementAttributeEquals('value', 'my value', $result);
+    }
+
+    /**
+     * @testdox ignores an ID that is "null".
+     */
+    public function testFormInputTextNull()
+    {
+        $result = $this->formBuilder->input(type: 'text', name: 'my-name', value: 'my value', options: ['id' => null]);
+
+        $this->assertElementIs('input', $result);
+        $this->assertElementDoesntHaveAttribute('id', $result);
+        $this->assertElementAttributeEquals('name', 'my-name', $result);
+        $this->assertElementAttributeEquals('type', 'text', $result);
+        $this->assertElementAttributeEquals('value', 'my value', $result);
+    }
+
+    /**
+     * @testdox ignores an ID that is boolean "false".
+     */
+    public function testFormInputTextFalse()
+    {
+        $result = $this->formBuilder->input(type: 'text', name: 'my-name', value: 'my value', options: ['id' => false]);
+
+        $this->assertElementIs('input', $result);
+        $this->assertElementDoesntHaveAttribute('id', $result);
+        $this->assertElementAttributeEquals('name', 'my-name', $result);
+        $this->assertElementAttributeEquals('type', 'text', $result);
+        $this->assertElementAttributeEquals('value', 'my value', $result);
+    }
+
+    /**
+     * @testdox accepts an ID that is an integer of zero.
+     */
+    public function testFormInputTextZero()
+    {
+        $result = $this->formBuilder->input(type: 'text', name: 'my-name', value: 'my value', options: ['id' => 0]);
+
+        $this->assertElementIs('input', $result);
+        $this->assertElementAttributeEquals('id', '0', $result);
+        $this->assertElementAttributeEquals('name', 'my-name', $result);
+        $this->assertElementAttributeEquals('type', 'text', $result);
+        $this->assertElementAttributeEquals('value', 'my value', $result);
+    }
+
+    /**
+     * @testdox can create a text input of type "email".
+     */
+    public function testFormInputEmail()
+    {
+        $result = $this->formBuilder->input(type: 'email', name: 'my-input', value: 'my value');
+
+        $this->assertElementIs('input', $result);
+        $this->assertElementDoesntHaveAttribute('id', $result);
+        $this->assertElementAttributeEquals('name', 'my-input', $result);
+        $this->assertElementAttributeEquals('type', 'email', $result);
+        $this->assertElementAttributeEquals('value', 'my value', $result);
+
+        $result = $this->formBuilder->label(name: 'my-input', value: 'my input label');
+        $result = $this->formBuilder->email(name: 'my-input', value: 'my value');
+
+        $this->assertElementIs('input', $result);
+        $this->assertElementAttributeEquals('id', 'my-input', $result);
+        $this->assertElementAttributeEquals('name', 'my-input', $result);
+        $this->assertElementAttributeEquals('type', 'email', $result);
+        $this->assertElementAttributeEquals('value', 'my value', $result);
+    }
+
+    /**
+     * @testdox can create a submit button.
+     * @see https://github.com/wintercms/winter/issues/864
+     */
+    public function testSubmit()
+    {
+        $result = $this->formBuilder->submit(value: 'Apply');
+
+        $this->assertElementIs('input', $result);
+        $this->assertElementAttributeEquals('type', 'submit', $result);
+        $this->assertElementAttributeEquals('value', 'Apply', $result);
+    }
+
+    /**
+     * @testdox can create a submit button with additional classes.
+     * @see https://github.com/wintercms/winter/issues/864
+     */
+    public function testSubmitWithClasses()
+    {
+        $result = $this->formBuilder->submit(value: 'Apply', options: ['class' => 'btn btn-primary']);
+
+        $this->assertElementIs('input', $result);
+        $this->assertElementAttributeEquals('type', 'submit', $result);
+        $this->assertElementAttributeEquals('class', 'btn btn-primary', $result);
+        $this->assertElementAttributeEquals('value', 'Apply', $result);
+    }
+
+    /**
+     * @testdox can create a standard button.
+     * @see https://github.com/wintercms/winter/issues/864
+     */
+    public function testButton()
+    {
+        $result = $this->formBuilder->button(value: 'Apply');
+
+        $this->assertElementIs('button', $result);
+        $this->assertElementAttributeEquals('type', 'button', $result);
+        $this->assertElementContainsText('Apply', $result);
+    }
+
+    /**
+     * @testdox can create a standard button that submits the form.
+     * @see https://github.com/wintercms/winter/issues/864
+     */
+    public function testButtonSubmitType()
+    {
+        $result = $this->formBuilder->button(value: 'Apply', options: [
+            'type' => 'submit',
+        ]);
+
+        $this->assertElementIs('button', $result);
+        $this->assertElementAttributeEquals('type', 'submit', $result);
+        $this->assertElementContainsText('Apply', $result);
     }
 }


### PR DESCRIPTION
Commit https://github.com/wintercms/storm/commit/2ef32346682c768a9d457c4dba6796f34b644eab made some adjustments to the input method arguments that resulted in the some attributes not being populated if the name of the input was not provided. This commit changes the structure of the condition so that these attributes are properly filled in.

I've also redone the tests using some custom assertions so that the order of the attributes does not matter when testing. The previous tests were a bit flimsy in this regard.

Fixes https://github.com/wintercms/winter/issues/864