### PR TITLE
Add json helper method to set payload as json-encoded value.

### DIFF
--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -449,7 +449,7 @@ class Http
     {
         if (!Str::isJson($payload)) {
             if (!$payload = json_encode($payload)) {
-                throw new ApplicationException('provided payload cannot be json_encoded ');
+                throw new ApplicationException('The provided payload failed to be encoded as JSON');
             }
         }
 

--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -115,7 +115,7 @@ class Http
     public $requestOptions = [];
 
     /**
-     * @var array Request data.
+     * @var array|string Request data.
      */
     public $requestData;
 
@@ -440,6 +440,20 @@ class Http
             }
         }
         return $headers;
+    }
+
+    /**
+     * Add JSON encoded payload
+     */
+    public function json(array|string $payload) : self
+    {
+        if (is_array($payload)) {
+            $payload = json_encode($payload);
+        }
+        $this->requestData = $payload;
+        $this->header('Content-Type', 'application/json');
+
+        return $this;
     }
 
     /**

--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -1,6 +1,7 @@
 <?php namespace Winter\Storm\Network;
 
 use Winter\Storm\Exception\ApplicationException;
+use Winter\Storm\Support\Str;
 
 /**
  * HTTP Network Access
@@ -452,10 +453,11 @@ class Http
             foreach ($key as $_key => $_value) {
                 $this->data($_key, $_value);
             }
-            return $this;
+        } elseif (is_null($value) && Str::isJson($key)) {
+            $this->requestData = $key;
+        } else {
+            $this->requestData[$key] = $value;
         }
-
-        $this->requestData[$key] = $value;
         return $this;
     }
 

--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -458,17 +458,13 @@ class Http
 
     /**
      * Add a data to the request.
-     * @param string $value
-     * @return self
      */
-    public function data($key, $value = null)
+    public function data(array|string $key, string $value = null): self
     {
         if (is_array($key)) {
             foreach ($key as $_key => $_value) {
                 $this->data($_key, $_value);
             }
-        } elseif (is_null($value) && Str::isJson($key)) {
-            $this->requestData = $key;
         } else {
             $this->requestData[$key] = $value;
         }

--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -445,7 +445,7 @@ class Http
     /**
      * Add JSON encoded payload
      */
-    public function json(array|string $payload) : self
+    public function json(array|string $payload): self
     {
         if (is_array($payload)) {
             $payload = json_encode($payload);

--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -445,11 +445,14 @@ class Http
     /**
      * Add JSON encoded payload
      */
-    public function json(array|string $payload): self
+    public function json(mixed $payload): self
     {
-        if (is_array($payload)) {
-            $payload = json_encode($payload);
+        if (!Str::isJson($payload)) {
+            if (!$payload = json_encode($payload)) {
+                throw new ApplicationException('provided payload cannot be json_encoded ');
+            }
         }
+
         $this->requestData = $payload;
         $this->header('Content-Type', 'application/json');
 


### PR DESCRIPTION
Allows doing this:
```php
$payload = [
    'key1' => 'value1',
    'key2' => 'value2'
];

$apiResult = Http::post($url, function ($http) use ($payload) {
    $http->json( $payload );
});

```
Instead of this:
```php
$payload = [
    'key1' => 'value1',
    'key2' => 'value2'
];

$apiResult = Http::post($url, function ($http) use ($payload) {
    $http->header('Content-Type', 'application/json; charset=utf-8');
    $http->setOption( CURLOPT_POSTFIELDS, json_encode($payload) );
```
