### PR TITLE
Remove max-depth restriction from getAvailablePaths

### DIFF
--- a/src/Halcyon/Datasource/FileDatasource.php
+++ b/src/Halcyon/Datasource/FileDatasource.php
@@ -342,10 +342,6 @@ class FileDatasource extends Datasource
             ? new RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->basePath))
             : [];
 
-        if (!is_array($it)) {
-            $it->setMaxDepth($this->maxDepth + 1);
-        }
-
         foreach ($it as $file) {
             if ($file->isDir()) {
                 continue;


### PR DESCRIPTION
This PR removes the limit put in place in https://github.com/wintercms/storm/pull/135 in order to fix https://github.com/wintercms/wn-blocks-plugin/issues/6.

From memory, I believe not restricting the path cache caused issues when using a combination of child themes and blocks which lead to a theme datasource structure of:
```
AutoDatasource: 
    - AutoDatasource:
        - FileDatasource - child
        - FileDatasource - parent
    - BlocksDatasourcce
``` 

![image](https://github.com/wintercms/storm/assets/31214002/67fc6393-9665-4cc8-b269-4eafaa88718b)

However after some testing I was not able to reproduce the error, therefore this PR reverts the change.
