### PR TITLE
Call model methods using event handler with default priority

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,16 +11,6 @@ parameters:
 			path: src/Auth/Models/Group.php
 
 		-
-			message: "#^Call to an undefined method Winter\\\\Storm\\\\Auth\\\\Models\\\\Group\\:\\:afterValidate\\(\\)\\.$#"
-			count: 1
-			path: src/Auth/Models/Group.php
-
-		-
-			message: "#^Call to an undefined method Winter\\\\Storm\\\\Auth\\\\Models\\\\Group\\:\\:beforeValidate\\(\\)\\.$#"
-			count: 1
-			path: src/Auth/Models/Group.php
-
-		-
 			message: "#^Call to an undefined method \\$this\\(Winter\\\\Storm\\\\Auth\\\\Models\\\\Role\\)\\:\\:getOriginalEncryptableValues\\(\\)\\.$#"
 			count: 1
 			path: src/Auth/Models/Role.php
@@ -31,27 +21,7 @@ parameters:
 			path: src/Auth/Models/Role.php
 
 		-
-			message: "#^Call to an undefined method Winter\\\\Storm\\\\Auth\\\\Models\\\\Role\\:\\:afterValidate\\(\\)\\.$#"
-			count: 1
-			path: src/Auth/Models/Role.php
-
-		-
-			message: "#^Call to an undefined method Winter\\\\Storm\\\\Auth\\\\Models\\\\Role\\:\\:beforeValidate\\(\\)\\.$#"
-			count: 1
-			path: src/Auth/Models/Role.php
-
-		-
 			message: "#^Call to an undefined method \\$this\\(Winter\\\\Storm\\\\Auth\\\\Models\\\\User\\)\\:\\:getOriginalEncryptableValues\\(\\)\\.$#"
-			count: 1
-			path: src/Auth/Models/User.php
-
-		-
-			message: "#^Call to an undefined method Winter\\\\Storm\\\\Auth\\\\Models\\\\User\\:\\:afterValidate\\(\\)\\.$#"
-			count: 1
-			path: src/Auth/Models/User.php
-
-		-
-			message: "#^Call to an undefined method Winter\\\\Storm\\\\Auth\\\\Models\\\\User\\:\\:beforeValidate\\(\\)\\.$#"
 			count: 1
 			path: src/Auth/Models/User.php
 

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -227,9 +227,10 @@ class Model extends EloquentModel implements ModelInterface
 
                 self::$eventMethod(function ($model) use ($method) {
                     if ($model->methodExists($method)) {
+                        // register a default priority(0) listener to call the model method
                         $model->bindEvent('model.' . $method, [$model, $method]);
                     }
-                    $model->fireEvent('model.' . $method);
+                    return $model->fireEvent('model.' . $method, true);
                 });
             }
         }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -227,7 +227,8 @@ class Model extends EloquentModel implements ModelInterface
 
                 self::$eventMethod(function ($model) use ($method) {
                     if ($model->methodExists($method)) {
-                        // register a default priority(0) listener to call the model method
+                        // Register the method as a listener with default priority
+                        // to allow for complete control over the execution order
                         $model->bindEvent('model.' . $method, [$model, $method]);
                     }
                     // Use a halting event; First listener that returns false cancels the event.

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -230,7 +230,7 @@ class Model extends EloquentModel implements ModelInterface
                         // register a default priority(0) listener to call the model method
                         $model->bindEvent('model.' . $method, [$model, $method]);
                     }
-                    return $model->fireEvent('model.' . $method, true);
+                    return $model->fireEvent('model.' . $method, halt:true);
                 });
             }
         }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -226,11 +226,10 @@ class Model extends EloquentModel implements ModelInterface
                 }
 
                 self::$eventMethod(function ($model) use ($method) {
-                    $model->fireEvent('model.' . $method);
-
                     if ($model->methodExists($method)) {
-                        return $model->$method();
+                        $model->bindEvent('model.' . $method, [$model, $method]);
                     }
+                    $model->fireEvent('model.' . $method);
                 });
             }
         }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -231,7 +231,9 @@ class Model extends EloquentModel implements ModelInterface
                         // to allow for complete control over the execution order
                         $model->bindEvent('model.' . $method, [$model, $method]);
                     }
-                    // First listener that returns a non-null result will cancel the further propagation of the event
+                    // First listener that returns a non-null result will cancel the
+                    // further propagation of the event; If that result is false, the
+                    // underlying action will get cancelled (e.g. creating, saving, deleting)
                     return $model->fireEvent('model.' . $method, halt: true);
                 });
             }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -231,8 +231,8 @@ class Model extends EloquentModel implements ModelInterface
                         // to allow for complete control over the execution order
                         $model->bindEvent('model.' . $method, [$model, $method]);
                     }
-                    // Use a halting event; First listener that returns false cancels the event.
-                    return $model->fireEvent('model.' . $method, halt:true);
+                    // First listener that returns a non-null result will cancel the further propagation of the event
+                    return $model->fireEvent('model.' . $method, halt: true);
                 });
             }
         }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -230,7 +230,7 @@ class Model extends EloquentModel implements ModelInterface
                         // register a default priority(0) listener to call the model method
                         $model->bindEvent('model.' . $method, [$model, $method]);
                     }
-                    // Use a halting event; First handler that returns a value wins.
+                    // Use a halting event; First listener that returns false cancels the event.
                     return $model->fireEvent('model.' . $method, halt:true);
                 });
             }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -230,6 +230,7 @@ class Model extends EloquentModel implements ModelInterface
                         // register a default priority(0) listener to call the model method
                         $model->bindEvent('model.' . $method, [$model, $method]);
                     }
+                    // Use a halting event; First handler that returns a value wins.
                     return $model->fireEvent('model.' . $method, halt:true);
                 });
             }

--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -174,6 +174,12 @@ trait Validation
             ? $this->throwOnValidation
             : true;
 
+        if ($this->methodExists('beforeValidate')) {
+            // Register the method as a listener with default priority
+            // to allow for complete control over the execution order
+            $model->bindEvent('model.beforeValidate', [$model, 'beforeValidate']);
+        }
+
         /**
          * @event model.beforeValidate
          * Called before the model is validated
@@ -186,16 +192,12 @@ trait Validation
          *     });
          *
          */
-        if (($this->fireModelEvent('validating') === false) || ($this->fireEvent('model.beforeValidate', [], true) === false)) {
+        if (($this->fireModelEvent('validating') === false) || ($this->fireEvent('model.beforeValidate', halt: true) === false)) {
             if ($throwOnValidation) {
                 throw new ModelException($this);
             }
 
             return false;
-        }
-
-        if ($this->methodExists('beforeValidate')) {
-            $this->beforeValidate();
         }
 
         /*
@@ -323,6 +325,12 @@ trait Validation
             }
         }
 
+        if ($this->methodExists('afterValidate')) {
+            // Register the method as a listener with default priority
+            // to allow for complete control over the execution order
+            $model->bindEvent('model.afterValidate', [$model, 'afterValidate']);
+        }
+
         /**
          * @event model.afterValidate
          * Called after the model is validated
@@ -335,11 +343,7 @@ trait Validation
          *
          */
         $this->fireModelEvent('validated', false);
-        $this->fireEvent('model.afterValidate');
-
-        if ($this->methodExists('afterValidate')) {
-            $this->afterValidate();
-        }
+        $this->fireEvent('model.afterValidate', halt: true);
 
         if (!$success && $throwOnValidation) {
             throw new ModelException($this);

--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -177,7 +177,7 @@ trait Validation
         if ($this->methodExists('beforeValidate')) {
             // Register the method as a listener with default priority
             // to allow for complete control over the execution order
-            $model->bindEvent('model.beforeValidate', [$model, 'beforeValidate']);
+            $this->bindEvent('model.beforeValidate', [$this, 'beforeValidate']);
         }
 
         /**
@@ -328,7 +328,7 @@ trait Validation
         if ($this->methodExists('afterValidate')) {
             // Register the method as a listener with default priority
             // to allow for complete control over the execution order
-            $model->bindEvent('model.afterValidate', [$model, 'afterValidate']);
+            $this->bindEvent('model.afterValidate', [$this, 'afterValidate']);
         }
 
         /**

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -239,11 +239,15 @@ class Model extends Extendable implements ModelInterface, ArrayAccess, Arrayable
                 }
 
                 self::$eventMethod(function ($model) use ($method) {
-                    $model->fireEvent('model.' . $method);
-
                     if ($model->methodExists($method)) {
-                        return $model->$method();
+                        // Register the method as a listener with default priority
+                        // to allow for complete control over the execution order
+                        $model->bindEvent('model.' . $method, [$model, $method]);
                     }
+                    // First listener that returns a non-null result will cancel the
+                    // further propagation of the event; If that result is false, the
+                    // underlying action will get cancelled (e.g. creating, saving, deleting)
+                    return $model->fireEvent('model.' . $method, halt: true);
                 });
             }
         }


### PR DESCRIPTION
Replaces #145 

This preserves current behavior: an event listener defined on the model with default priority (0) will get called first, then the model method will get called (through an event listener with default priority).

If an event listener uses a LOWER priority (e.g. -1), the model method will get called first (because its priority is 0 by default)

Note: there is still one thing I'd like to get clarified: an event listener defined in a plugin's boot method with default priority(0) will get called BEFORE the listener that calls the model method... so that means the Plugin's event listeners get registered FIRST, before the event listeners defined in the Model's `bootNicerEvents()` method... anyone care to explain why that is ?

My guess is that Plugin's `boot()` method gets called before any model are instanciated, which makes sense, right?