### PR TITLE
[PHP 8.3] Fix `get_class()` deprecations

### DIFF
--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -386,7 +386,7 @@ trait ExtendableTrait
             }
         }
 
-        $parent = get_parent_class();
+        $parent = get_parent_class($this);
         if ($parent !== false && method_exists($parent, '__get')) {
             return parent::__get($name);
         }
@@ -413,7 +413,7 @@ trait ExtendableTrait
         /*
          * This targets trait usage in particular
          */
-        $parent = get_parent_class();
+        $parent = get_parent_class($this);
         if ($parent !== false && method_exists($parent, '__set')) {
             parent::__set($name, $value);
         }
@@ -457,7 +457,7 @@ trait ExtendableTrait
             }
         }
 
-        $parent = get_parent_class();
+        $parent = get_parent_class($this);
         if ($parent !== false && method_exists($parent, '__call')) {
             return parent::__call($name, $params);
         }


### PR DESCRIPTION
In PHP 8.3, [calling `get_class()` and `get_parent_class()` functions without arguments is deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated).

This fixes them with identical alternatives that do not cause the deprecation notice.

References:
 - [PHP RFC: Deprecate functions with overloaded signatures](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
 - [PHP 8.3: get_class() and get_parent_class() function calls without arguments deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated)

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->