### PR TITLE
Remove deprecated "get_parent_class" calls in Extendable trait.

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -71,6 +71,11 @@ parameters:
 			path: src/Database/Model.php
 
 		-
+			message: "#^Static property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$dispatcher \\(Illuminate\\\\Contracts\\\\Events\\\\Dispatcher\\) in isset\\(\\) is not nullable\\.$#"
+			count: 1
+			path: src/Database/Model.php
+
+		-
 			message: "#^Call to an undefined method Winter\\\\Storm\\\\Database\\\\Model\\:\\:errors\\(\\)\\.$#"
 			count: 1
 			path: src/Database/ModelException.php
@@ -709,21 +714,6 @@ parameters:
 			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:getParentId\\(\\)\\.$#"
 			count: 1
 			path: src/Database/TreeCollection.php
-
-		-
-			message: "#^Winter\\\\Storm\\\\Extension\\\\Extendable\\:\\:extendableCall\\(\\) calls parent\\:\\:__call\\(\\) but Winter\\\\Storm\\\\Extension\\\\Extendable does not extend any class\\.$#"
-			count: 1
-			path: src/Extension/Extendable.php
-
-		-
-			message: "#^Winter\\\\Storm\\\\Extension\\\\Extendable\\:\\:extendableGet\\(\\) calls parent\\:\\:__get\\(\\) but Winter\\\\Storm\\\\Extension\\\\Extendable does not extend any class\\.$#"
-			count: 1
-			path: src/Extension/Extendable.php
-
-		-
-			message: "#^Winter\\\\Storm\\\\Extension\\\\Extendable\\:\\:extendableSet\\(\\) calls parent\\:\\:__set\\(\\) but Winter\\\\Storm\\\\Extension\\\\Extendable does not extend any class\\.$#"
-			count: 1
-			path: src/Extension/Extendable.php
 
 		-
 			message: "#^Parameter \\#2 \\$data \\(array\\) of method Winter\\\\Storm\\\\Mail\\\\Mailer\\:\\:queue\\(\\) should be compatible with parameter \\$queue \\(string\\|null\\) of method Illuminate\\\\Contracts\\\\Mail\\\\MailQueue\\:\\:queue\\(\\)$#"

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1,6 +1,6 @@
 <?php namespace Winter\Storm\Database;
 
-use Cache;
+use Illuminate\Support\Facades\Cache;
 use Closure;
 use DateTimeInterface;
 use Exception;
@@ -18,7 +18,6 @@ use Winter\Storm\Support\Str;
  *
  * @author Alexey Bobkov, Samuel Georges
  *
- * @phpstan-property \Illuminate\Contracts\Events\Dispatcher|null $dispatcher
  * @method static mixed extend(callable $callback, bool $scoped = false, ?object $outerScope = null)
  */
 class Model extends EloquentModel implements ModelInterface

--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -416,7 +416,7 @@ trait ExtendableTrait
          */
         $parent = $this->extensionGetParentClass();
         if ($parent !== false && $this->extensionMethodExists($parent, '__set')) {
-            return $this->extensionCallMethod($parent, '__set', [$name, $value]);
+            $this->extensionCallMethod($parent, '__set', [$name, $value]);
         }
 
         /*

--- a/tests/Database/UpdaterTest.php
+++ b/tests/Database/UpdaterTest.php
@@ -4,6 +4,8 @@ use Winter\Storm\Database\Updater;
 
 class UpdaterTest extends TestCase
 {
+    protected Updater $updater;
+
     public function setUp(): void
     {
         include_once __DIR__.'/../fixtures/database/SampleClass.php';

--- a/tests/Foundation/ApplicationTest.php
+++ b/tests/Foundation/ApplicationTest.php
@@ -5,6 +5,8 @@ use Winter\Storm\Filesystem\PathResolver;
 
 class ApplicationTest extends TestCase
 {
+    protected string $basePath;
+
     protected function setUp(): void
     {
         // Mock application

--- a/tests/Html/BlockBuilderTest.php
+++ b/tests/Html/BlockBuilderTest.php
@@ -4,6 +4,8 @@ use Winter\Storm\Html\BlockBuilder;
 
 class BlockBuilderTest extends TestCase
 {
+    protected BlockBuilder $Block;
+
     public function setUp(): void
     {
         $this->Block = new BlockBuilder();

--- a/tests/Support/EventFakeTest.php
+++ b/tests/Support/EventFakeTest.php
@@ -5,6 +5,8 @@ use Winter\Storm\Support\Testing\Fakes\EventFake;
 
 class EventFakeTest extends TestCase
 {
+    protected EventFake $faker;
+
     public function setUp(): void
     {
         $this->faker = new EventFake(new Dispatcher);


### PR DESCRIPTION
This uses Reflection to instead determine the parent class and available magic methods to pass through to. In order to prevent infinite looping (which could've potentially been a problem before), it will also ignore any "extendable" classes when determining the parent.

Also fixed some tests that were using undefined class properties, and were also throwing deprecation errors.

Replaces https://github.com/wintercms/storm/pull/152