### PR TITLE
Clear model cache when using upsert

### DIFF
--- a/src/Database/Builder.php
+++ b/src/Database/Builder.php
@@ -222,6 +222,8 @@ class Builder extends BuilderModel
             return 0;
         }
 
+        $this->clearDuplicateCache();
+
         if (!is_array(reset($values))) {
             $values = [$values];
         }

--- a/src/Database/QueryBuilder.php
+++ b/src/Database/QueryBuilder.php
@@ -311,6 +311,8 @@ class QueryBuilder extends QueryBuilderBase
             return 0;
         }
 
+        $this->clearDuplicateCache();
+
         if ($update === []) {
             return (int) $this->insert($values);
         }


### PR DESCRIPTION
Currently a memory cache is used to avoid making unnecessary calls to the database, when there have been no changes.

This cache is cleared by executing insert, update, delete or truncate. With this change, the cache is also cleared when using upsert.

- Clear model cache when using upsert
- Testing for upsert with memory cache