### PR TITLE
Ensure Event::forget() also cleans up prioritized listeners

### DIFF
--- a/src/Events/Dispatcher.php
+++ b/src/Events/Dispatcher.php
@@ -313,4 +313,15 @@ class Dispatcher extends BaseDispatcher
             ? $this->createCallbackForListenerRunningAfterCommits($listener, $method)
             : [$listener, $method];
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function forget($event)
+    {
+        parent::forget($event);
+        if (isset($this->sorted[$event])) {
+            unset($this->sorted[$event]);
+        }
+    }
 }


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->