### PR TITLE
Fix dynamic properties on PHP 8.2+

### DIFF
--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -210,7 +210,6 @@ trait ExtendableTrait
         self::$extendableGuardProperties = false;
 
         array_set($this->extensionData['dynamicProperties'], $dynamicName, $value);
-        $this->extendableSet($dynamicName, $value);
 
         self::$extendableGuardProperties = true;
     }
@@ -419,7 +418,7 @@ trait ExtendableTrait
          * Setting an undefined property
          */
         if (!self::$extendableGuardProperties) {
-            $this->{$name} = $value;
+            array_set($this->extensionData['dynamicProperties'], $name, $value);
         }
     }
 

--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -209,11 +209,7 @@ trait ExtendableTrait
         }
         self::$extendableGuardProperties = false;
 
-        if (!property_exists($this, $dynamicName)) {
-            $this->{$dynamicName} = $value;
-        }
-
-        $this->extensionData['dynamicProperties'][] = $dynamicName;
+        array_set($this->extensionData['dynamicProperties'], $dynamicName, $value);
 
         self::$extendableGuardProperties = true;
     }
@@ -327,12 +323,7 @@ trait ExtendableTrait
      */
     public function getDynamicProperties()
     {
-        $result = [];
-        $propertyNames = $this->extensionData['dynamicProperties'];
-        foreach ($propertyNames as $propName) {
-            $result[$propName] = $this->{$propName};
-        }
-        return $result;
+        return $this->extensionData['dynamicProperties'];
     }
 
     /**
@@ -378,6 +369,10 @@ trait ExtendableTrait
      */
     public function extendableGet($name)
     {
+        if (isset($this->extensionData['dynamicProperties'][$name])) {
+            return $this->extensionData['dynamicProperties'][$name];
+        }
+
         foreach ($this->extensionData['extensions'] as $extensionObject) {
             if (
                 property_exists($extensionObject, $name) &&

--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -210,6 +210,7 @@ trait ExtendableTrait
         self::$extendableGuardProperties = false;
 
         array_set($this->extensionData['dynamicProperties'], $dynamicName, $value);
+        $this->extendableSet($dynamicName, $value);
 
         self::$extendableGuardProperties = true;
     }

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -1603,6 +1603,15 @@ class Model extends Extendable implements ModelInterface, ArrayAccess, Arrayable
         static::$mutatorCache[$class] = $mutatedAttributes;
     }
 
+    public function addDynamicProperty($dynamicName, $value = null)
+    {
+        if (isset($this->attributes[$dynamicName])) {
+            return;
+        }
+
+        $this->setAttribute($dynamicName, $value);
+    }
+
     /**
      * Dynamically retrieve attributes on the model.
      *

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -1608,10 +1608,10 @@ class Model extends Extendable implements ModelInterface, ArrayAccess, Arrayable
         if (isset($this->attributes[$dynamicName])) {
             return;
         }
-
-        parent::addDynamicProperty($dynamicName, $value);
-
         $this->setAttribute($dynamicName, $value);
+
+        // only need to be set to exclude those attributes from getSettingsAttribute()
+        array_set($this->extensionData['dynamicProperties'], $dynamicName, null);
     }
 
     /**

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -1609,6 +1609,8 @@ class Model extends Extendable implements ModelInterface, ArrayAccess, Arrayable
             return;
         }
 
+        parent::addDynamicProperty($dynamicName, $value);
+
         $this->setAttribute($dynamicName, $value);
     }
 

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -1603,17 +1603,6 @@ class Model extends Extendable implements ModelInterface, ArrayAccess, Arrayable
         static::$mutatorCache[$class] = $mutatedAttributes;
     }
 
-    public function addDynamicProperty($dynamicName, $value = null)
-    {
-        if (isset($this->attributes[$dynamicName])) {
-            return;
-        }
-        $this->setAttribute($dynamicName, $value);
-
-        // only need to be set to exclude those attributes from getSettingsAttribute()
-        array_set($this->extensionData['dynamicProperties'], $dynamicName, null);
-    }
-
     /**
      * Dynamically retrieve attributes on the model.
      *

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -1611,7 +1611,7 @@ class Model extends Extendable implements ModelInterface, ArrayAccess, Arrayable
      */
     public function __get($key)
     {
-        return $this->getAttribute($key);
+        return $this->extendableGet($key) ?? $this->getAttribute($key);
     }
 
     /**

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -1611,6 +1611,7 @@ class Model extends Extendable implements ModelInterface, ArrayAccess, Arrayable
      */
     public function __get($key)
     {
+        // try the dynamic properties first, then the local attributes array
         return $this->extendableGet($key) ?? $this->getAttribute($key);
     }
 

--- a/src/Router/RoutingServiceProvider.php
+++ b/src/Router/RoutingServiceProvider.php
@@ -2,9 +2,11 @@
 
 namespace Winter\Storm\Router;
 
-use Illuminate\Contracts\Routing\UrlGenerator as UrlGeneratorContract;
 use Illuminate\Routing\RoutingServiceProvider as RoutingServiceProviderBase;
 
+/**
+ * @property \Winter\Storm\Foundation\Application $app
+ */
 class RoutingServiceProvider extends RoutingServiceProviderBase
 {
     /**
@@ -60,7 +62,7 @@ class RoutingServiceProvider extends RoutingServiceProviderBase
             );
         });
 
-        $this->app->extend('url', function (UrlGeneratorContract $url, $app) {
+        $this->app->extend('url', function (UrlGenerator $url, $app) {
             // Next we will set a few service resolvers on the URL generator so it can
             // get the information it needs to function. This just provides some of
             // the convenience features to this URL generator like "signed" URLs.

--- a/tests/Extension/ExtendableTest.php
+++ b/tests/Extension/ExtendableTest.php
@@ -65,7 +65,7 @@ class ExtendableTest extends TestCase
         $this->assertFalse(property_exists($subject, 'newAttribute'));
         $subject->addDynamicProperty('dynamicAttribute', 'Test');
         $this->assertEquals('Test', $subject->dynamicAttribute);
-        $this->assertTrue(property_exists($subject, 'dynamicAttribute'));
+        $this->assertTrue($subject->propertyExists('dynamicAttribute'));
     }
 
     public function testDynamicallyExtendingClass()

--- a/tests/Halcyon/HalcyonModelTest.php
+++ b/tests/Halcyon/HalcyonModelTest.php
@@ -348,6 +348,17 @@ ESC;
         $this->assertEquals(['about.htm', 'home.htm'], $files);
     }
 
+    public function testAddDynamicPoperty()
+    {
+        $page = HalcyonTestPage::find('home');
+
+        $page->addDynamicProperty('myDynamicProperty', 'myDynamicPropertyValue');
+        $this->assertEquals('myDynamicPropertyValue', $page->myDynamicProperty);
+
+        // Dynamic properties should not be saved to DB layer
+        $this->assertArrayNotHasKey('myDynamicProperty', $page->attributes);
+    }
+
     //
     // House keeping
     //

--- a/tests/Halcyon/HalcyonModelTest.php
+++ b/tests/Halcyon/HalcyonModelTest.php
@@ -29,7 +29,6 @@ class HalcyonModelTest extends TestCase
     {
         $pages = HalcyonTestPage::all();
 
-        $this->assertCount(2, $pages);
         $this->assertContains('about.htm', $pages->lists('fileName'));
         $this->assertContains('home.htm', $pages->lists('fileName'));
     }
@@ -347,27 +346,6 @@ ESC;
 
         $this->assertCount(2, $files);
         $this->assertEquals(['about.htm', 'home.htm'], $files);
-    }
-
-    public function testAddDynamicPoperty()
-    {
-        @unlink($targetFile = __DIR__.'/../fixtures/halcyon/themes/theme1/pages/dynamicproperty.htm');
-
-        $page = HalcyonTestPage::create([
-            'fileName' => 'dynamicproperty',
-            'title' => 'Add Dynamic Property',
-            'markup' => '<p>Foo bar!</p>'
-        ]);
-
-        $page->addDynamicProperty('myDynamicProperty', 'myDynamicPropertyValue');
-        $this->assertArrayHasKey('myDynamicProperty', $page->attributes);
-        $this->assertEquals('myDynamicPropertyValue', $page->myDynamicProperty);
-        $page->save();
-        $page = HalcyonTestPage::find('dynamicproperty');
-        $this->assertNotNull($page);
-        // Dynamic properties should not be saved to DB layer
-        $this->assertArrayNotHasKey('myDynamicProperty', $page->attributes);
-        @unlink($targetFile);
     }
 
     //


### PR DESCRIPTION
PHP 8.2+ has deprecated dynamic properties. This PR addresses the issue by using the extensionData['dynamicProperties'] array for the dynamic properties.