### PR TITLE
Override Symfony Process.

### DIFF
--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -20,7 +20,10 @@ class Process extends BaseProcess
      */
     public function setTty(bool $tty): static
     {
-        if (($openBasedir = ini_get('open_basedir')) && !@is_readable('/dev/tty')) {
+        $isUnix = '/' === \DIRECTORY_SEPARATOR;
+        $openBasedir = ini_get('open_basedir');
+
+        if ($tty && $isUnix && !empty($openBasedir) && !@is_readable('/dev/tty')) {
             throw new RuntimeException("\nYou have PHP open_basedir restrictions enabled.\nTTY mode has been disabled because access to /dev/tty is not allowed.\n");
         }
 

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -12,7 +12,7 @@ use Symfony\Component\Process\Exception\RuntimeException;
 class Process extends BaseProcess
 {
     /**
-     * Enables or disables the TTY mode.
+     * Enables or disables TTY mode.
      *
      * @throws RuntimeException In case the TTY mode is not supported or /dev/tty is not accessible.
      */
@@ -20,7 +20,7 @@ class Process extends BaseProcess
     {
         if ($tty && '/' === \DIRECTORY_SEPARATOR) {
             try {
-                $readable = is_writable('/dev/tty');
+                $writable = is_writable('/dev/tty');
             } catch (\Throwable $e) {
                 throw new RuntimeException($e->getMessage());
             }

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -16,11 +16,12 @@ class Process extends BaseProcess
      * @return $this
      *
      * @throws RuntimeException In case the TTY mode is not supported
+     * @throws ApplicationException In case /dev/tty is not accessible
      */
     public function setTty(bool $tty): static
     {
         if (($openBasedir = ini_get('open_basedir')) && !@is_readable('/dev/tty')) {
-            throw new \SystemException("\nYou have PHP open_basedir restricted for your environment.\nTTY mode has been disabled.\n");
+            throw new \ApplicationException("\nYou have PHP open_basedir restricted for your environment.\nTTY mode has been disabled.\n");
         }
 
         return parent::setTty($tty);

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -25,8 +25,8 @@ class Process extends BaseProcess
     {
         if ($tty && '/' === \DIRECTORY_SEPARATOR) {
             try {
-                // will trigger an exception if open_basedir restrictions prevent /dev/tty access
-                $writable = is_writable('/dev/tty');
+                // trigger exception if open_basedir restrictions prevent /dev/tty access
+                $stat = stat('/dev/tty');
             } catch (\Throwable $e) {
                 throw new RuntimeException($e->getMessage());
             }

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -1,7 +1,6 @@
 <?php namespace Winter\Storm\Console;
 
 use Symfony\Component\Process\Process as BaseProcess;
-use Winter\Storm\Exception\ApplicationException;
 
 /**
  * Process class
@@ -16,13 +15,12 @@ class Process extends BaseProcess
      *
      * @return $this
      *
-     * @throws RuntimeException In case the TTY mode is not supported
-     * @throws ApplicationException In case /dev/tty is not accessible
+     * @throws RuntimeException In case the TTY mode is not supported or /dev/tty is not accessible.
      */
     public function setTty(bool $tty): static
     {
         if (($openBasedir = ini_get('open_basedir')) && !@is_readable('/dev/tty')) {
-            throw new ApplicationException("\nYou have PHP open_basedir restricted for your environment.\nTTY mode has been disabled.\n");
+            throw new RuntimeException("\nYou have PHP open_basedir restricted for your environment.\nTTY mode has been disabled.\n");
         }
 
         return parent::setTty($tty);

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -20,6 +20,7 @@ class Process extends BaseProcess
     {
         if ($tty && '/' === \DIRECTORY_SEPARATOR) {
             try {
+                // will trigger an exception if open_basedir restrictions prevent /dev/tty access
                 $writable = is_writable('/dev/tty');
             } catch (\Throwable $e) {
                 throw new RuntimeException($e->getMessage());

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -1,6 +1,7 @@
 <?php namespace Winter\Storm\Console;
 
 use Symfony\Component\Process\Process as BaseProcess;
+use Symfony\Component\Process\Exception\RuntimeException;
 
 /**
  * Process class

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -20,11 +20,12 @@ class Process extends BaseProcess
      */
     public function setTty(bool $tty): static
     {
-        $isUnix = '/' === \DIRECTORY_SEPARATOR;
-        $openBasedir = ini_get('open_basedir');
-
-        if ($tty && $isUnix && !empty($openBasedir) && !@is_readable('/dev/tty')) {
-            throw new RuntimeException("You have PHP open_basedir restrictions enabled.\nTTY mode has been disabled because access to /dev/tty is not allowed.");
+        if ($tty && '/' === \DIRECTORY_SEPARATOR) {
+            try {
+                is_readable('/dev/tty');
+            } catch (\Exception $e) {
+                throw new RuntimeException($e->getMessage());
+            }
         }
 
         return parent::setTty($tty);

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -1,6 +1,7 @@
 <?php namespace Winter\Storm\Console;
 
 use Symfony\Component\Process\Process as BaseProcess;
+use Winter\Storm\Exception\ApplicationException;
 
 /**
  * Process class
@@ -21,7 +22,7 @@ class Process extends BaseProcess
     public function setTty(bool $tty): static
     {
         if (($openBasedir = ini_get('open_basedir')) && !@is_readable('/dev/tty')) {
-            throw new \ApplicationException("\nYou have PHP open_basedir restricted for your environment.\nTTY mode has been disabled.\n");
+            throw new ApplicationException("\nYou have PHP open_basedir restricted for your environment.\nTTY mode has been disabled.\n");
         }
 
         return parent::setTty($tty);

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -21,7 +21,7 @@ class Process extends BaseProcess
     public function setTty(bool $tty): static
     {
         if (($openBasedir = ini_get('open_basedir')) && !@is_readable('/dev/tty')) {
-            throw new RuntimeException("\nYou have PHP open_basedir restricted for your environment.\nTTY mode has been disabled.\n");
+            throw new RuntimeException("\nYou have PHP open_basedir restrictions enabled.\nTTY mode has been disabled because access to /dev/tty is not allowed.\n");
         }
 
         return parent::setTty($tty);

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -20,7 +20,7 @@ class Process extends BaseProcess
     {
         if ($tty && '/' === \DIRECTORY_SEPARATOR) {
             try {
-                $readable = is_readable('/dev/tty');
+                $readable = is_writable('/dev/tty');
             } catch (\Throwable $e) {
                 throw new RuntimeException($e->getMessage());
             }

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -22,7 +22,7 @@ class Process extends BaseProcess
     {
         if ($tty && '/' === \DIRECTORY_SEPARATOR) {
             try {
-                is_readable('/dev/tty');
+                $readable = is_readable('/dev/tty');
             } catch (\Exception $e) {
                 throw new RuntimeException($e->getMessage());
             }

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -5,7 +5,12 @@ use Symfony\Component\Process\Exception\RuntimeException;
 
 /**
  * Process class
- * overrides Symfony Process
+ *
+ * Fixes this symfony issue:
+ *     https://github.com/symfony/symfony/issues/54874
+ *
+ * Not needed if the following PR gets merged:
+ *     https://github.com/symfony/symfony/pull/54863
  *
  * @author Marc Jauvin
  */

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -1,0 +1,28 @@
+<?php namespace Winter\Storm\Console;
+
+use Symfony\Component\Process\Process as BaseProcess;
+
+/**
+ * Process class
+ * overrides Symfony Process
+ *
+ * @author Marc Jauvin
+ */
+class Process extends BaseProcess
+{
+    /**
+     * Enables or disables the TTY mode.
+     *
+     * @return $this
+     *
+     * @throws RuntimeException In case the TTY mode is not supported
+     */
+    public function setTty(bool $tty): static
+    {
+        if (($openBasedir = ini_get('open_basedir')) && !@is_readable('/dev/tty')) {
+            throw new \SystemException("\nYou have PHP open_basedir restricted for your environment.\nTTY mode has been disabled.\n");
+        }
+
+        return parent::setTty($tty);
+    }
+}

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -24,7 +24,7 @@ class Process extends BaseProcess
         $openBasedir = ini_get('open_basedir');
 
         if ($tty && $isUnix && !empty($openBasedir) && !@is_readable('/dev/tty')) {
-            throw new RuntimeException("\nYou have PHP open_basedir restrictions enabled.\nTTY mode has been disabled because access to /dev/tty is not allowed.\n");
+            throw new RuntimeException("You have PHP open_basedir restrictions enabled.\nTTY mode has been disabled because access to /dev/tty is not allowed.");
         }
 
         return parent::setTty($tty);

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -26,7 +26,7 @@ class Process extends BaseProcess
         if ($tty && '/' === \DIRECTORY_SEPARATOR) {
             try {
                 // trigger exception if open_basedir restrictions prevent /dev/tty access
-                $exists = file_exists('/dev/tty');
+                $status = stat('/dev/tty');
             } catch (\Throwable $e) {
                 throw new RuntimeException($e->getMessage());
             }

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -26,7 +26,7 @@ class Process extends BaseProcess
         if ($tty && '/' === \DIRECTORY_SEPARATOR) {
             try {
                 // trigger exception if open_basedir restrictions prevent /dev/tty access
-                $stat = stat('/dev/tty');
+                $exists = file_exists('/dev/tty');
             } catch (\Throwable $e) {
                 throw new RuntimeException($e->getMessage());
             }

--- a/src/Console/Process.php
+++ b/src/Console/Process.php
@@ -14,8 +14,6 @@ class Process extends BaseProcess
     /**
      * Enables or disables the TTY mode.
      *
-     * @return $this
-     *
      * @throws RuntimeException In case the TTY mode is not supported or /dev/tty is not accessible.
      */
     public function setTty(bool $tty): static
@@ -23,7 +21,7 @@ class Process extends BaseProcess
         if ($tty && '/' === \DIRECTORY_SEPARATOR) {
             try {
                 $readable = is_readable('/dev/tty');
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 throw new RuntimeException($e->getMessage());
             }
         }


### PR DESCRIPTION
This is required in order to handle an exception when open_basedir restrictions are in effect, preventing a process to be created with TTY mode enabled.