### PR TITLE
Qualify orderBy column with table name to avoid conflicts

### DIFF
--- a/src/Database/SortableScope.php
+++ b/src/Database/SortableScope.php
@@ -17,7 +17,7 @@ class SortableScope implements ScopeInterface
     {
         // Only apply the scope when no other explicit orders have been set
         if (empty($builder->getQuery()->orders) && empty($builder->getQuery()->unionOrders)) {
-            $builder->orderBy($model->getSortOrderColumn());
+            $builder->orderBy($model->qualifyColumn($model->getSortOrderColumn()));
         }
     }
 }

--- a/tests/Database/SortableTest.php
+++ b/tests/Database/SortableTest.php
@@ -7,7 +7,7 @@ class SortableTest extends DbTestCase
         $model = new TestSortableModel();
         $query = $model->newQuery()->toSql();
 
-        $this->assertEquals('select * from "test" order by "sort_order" asc', $query);
+        $this->assertEquals('select * from "test" order by "test.sort_order" asc', $query);
     }
 
     public function testCustomSortOrderByIsAutomaticallyAdded()

--- a/tests/Database/SortableTest.php
+++ b/tests/Database/SortableTest.php
@@ -7,7 +7,7 @@ class SortableTest extends DbTestCase
         $model = new TestSortableModel();
         $query = $model->newQuery()->toSql();
 
-        $this->assertEquals('select * from "test" order by "test.sort_order" asc', $query);
+        $this->assertEquals('select * from "test" order by "test"."sort_order" asc', $query);
     }
 
     public function testCustomSortOrderByIsAutomaticallyAdded()
@@ -15,7 +15,7 @@ class SortableTest extends DbTestCase
         $model = new TestCustomSortableModel();
         $query = $model->newQuery()->toSql();
 
-        $this->assertEquals('select * from "test" order by "rank" asc', $query);
+        $this->assertEquals('select * from "test" order by "test"."rank" asc', $query);
     }
 
     public function testOrderByCanBeOverridden()


### PR DESCRIPTION
This prevents potential conflicts with a sort column name introduced in a pivot table.