### PR TITLE
Fix infinite loop when using HasSortableRelations on a model with a self-referencing relationship

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
         - src/Parse/PHP/ArrayFile.php
         - src/Parse/PHP/ArrayPrinter.php
         - src/Foundation/Console/KeyGenerateCommand.php
+        - src/Scaffold/GeneratorCommand.php
     disableSchemaScan: true
     databaseMigrationsPath:
         - src/Auth/Migrations

--- a/src/Database/Traits/HasSortableRelations.php
+++ b/src/Database/Traits/HasSortableRelations.php
@@ -57,19 +57,18 @@ trait HasSortableRelations
         });
 
         foreach ($sortableRelations as $relationName => $column) {
-            $relation = $this->$relationName();
-            if (method_exists($relation, 'updateExistingPivot')) {
-                // Make sure all pivot-based defined sortable relations load the sort_order column as pivot data.
-                $definition = $this->getRelationDefinition($relationName);
-                $pivot = array_wrap(array_get($definition, 'pivot', []));
+            $realtionType = $this->getRelationType($relationName);
+            if (!in_array($realtionType, ['belongsToMany', 'morphToMany'])) {
+                continue;
+            }
+            $definition = $this->getRelationDefinition($relationName);
+            $pivot = array_wrap(array_get($definition, 'pivot', []));
 
-                if (!in_array($column, $pivot)) {
-                    $pivot[] = $column;
-                    $definition['pivot'] = $pivot;
-
-                    $relationType = $this->getRelationType($relationName);
-                    $this->$relationType[$relationName] = $definition;
-                }
+            if (!in_array($column, $pivot)) {
+                // Make sure the sort order column is available as pivot data.
+                $pivot[] = $column;
+                $definition['pivot'] = $pivot;
+                $this->$relationType[$relationName] = $definition;
             }
         }
     }

--- a/src/Database/Traits/HasSortableRelations.php
+++ b/src/Database/Traits/HasSortableRelations.php
@@ -57,8 +57,8 @@ trait HasSortableRelations
         });
 
         foreach ($sortableRelations as $relationName => $column) {
-            $realtionType = $this->getRelationType($relationName);
-            if (!in_array($realtionType, ['belongsToMany', 'morphToMany'])) {
+            $relationType = $this->getRelationType($relationName);
+            if (!in_array($relationType, ['belongsToMany', 'morphToMany'])) {
                 continue;
             }
             $definition = $this->getRelationDefinition($relationName);

--- a/tests/Database/Traits/HasSortableRelationsTest.php
+++ b/tests/Database/Traits/HasSortableRelationsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+class HasSortableRelationsTest extends DbTestCase
+{
+    public function testForInfiniteLoop()
+    {
+        $model = new TestModel();
+        $this->assertTrue($model instanceof TestModel);
+    }
+}
+
+/*
+* Class with HasSortableRelations trait
+*/
+class TestModel extends \Winter\Storm\Database\Model
+{
+    use \Winter\Storm\Database\Traits\HasSortableRelations;
+
+    protected $sortableRelations = [
+        'relationToSelf' => 'sort_order',
+    ];
+
+    public $belongsToMany = [
+        'relationToSelf' => TestModel::class,
+    ];
+}

--- a/tests/Database/Traits/HasSortableRelationsTest.php
+++ b/tests/Database/Traits/HasSortableRelationsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class HasSortableRelationsTest extends DbTestCase
+class HasSortableRelationsTest extends TestCase
 {
     public function testForInfiniteLoop()
     {


### PR DESCRIPTION
I have model that has a `belongsToMany` relation on itself and somehow, calling the relation on the model (i.e. `$model->$relationName()`) creates an infinite loop.

Using only the model relation definition solves the issue.