### PR TITLE
Support project relative paths to sqlite databases regardless of webroot

### DIFF
--- a/src/Database/Connectors/ConnectionFactory.php
+++ b/src/Database/Connectors/ConnectionFactory.php
@@ -39,6 +39,23 @@ class ConnectionFactory extends ConnectionFactoryBase
     }
 
     /**
+     * Create a connector instance based on the configuration.
+     *
+     * @param  array  $config
+     * @return \Illuminate\Database\Connectors\ConnectorInterface
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function createConnector(array $config)
+    {
+        if (array_get($config, 'driver') === 'sqlite') {
+            return new SQLiteConnector;
+        } else {
+            return parent::createConnector($config);
+        }
+    }
+
+    /**
      * Create a new connection instance.
      *
      * @param  string   $driver

--- a/src/Database/Connectors/SQLiteConnector.php
+++ b/src/Database/Connectors/SQLiteConnector.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Winter\Storm\Database\Connectors;
+
+use Illuminate\Database\Connectors\SQLiteConnector as BaseSQLiteConnector;
+use Illuminate\Database\SQLiteDatabaseDoesNotExistException;
+
+class SQLiteConnector extends BaseSQLiteConnector
+{
+    /**
+     * Establish a database connection.
+     *
+     * @param  array  $config
+     * @return \PDO
+     *
+     * @throws \Illuminate\Database\SQLiteDatabaseDoesNotExistException
+     */
+    public function connect(array $config)
+    {
+        $options = $this->getOptions($config);
+
+        // SQLite supports "in-memory" databases that only last as long as the owning
+        // connection does. These are useful for tests or for short lifetime store
+        // querying. In-memory databases may only have a single open connection.
+        if ($config['database'] === ':memory:') {
+            return $this->createConnection('sqlite::memory:', $config, $options);
+        }
+
+        $path = realpath($config['database']);
+        if (!file_exists($path)) {
+            $path = realpath(base_path($config['database']));
+        }
+
+        // Here we'll verify that the SQLite database exists before going any further
+        // as the developer probably wants to know if the database exists and this
+        // SQLite driver will not throw any exception if it does not by default.
+        if ($path === false) {
+            throw new SQLiteDatabaseDoesNotExistException($config['database']);
+        }
+
+        return $this->createConnection("sqlite:{$path}", $config, $options);
+    }
+}


### PR DESCRIPTION
This allows setting SQLite db path relative to app root, even when running with mirrored install.