### PR TITLE
Fix multiple listeners being attached to models

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -228,7 +228,7 @@ class Model extends EloquentModel implements ModelInterface
                     if ($model->methodExists($method)) {
                         // Register the method as a listener with default priority
                         // to allow for complete control over the execution order
-                        $model->bindEvent('model.' . $method, [$model, $method]);
+                        $model->bindEventOnce('model.' . $method, [$model, $method]);
                     }
                     // First listener that returns a non-null result will cancel the
                     // further propagation of the event; If that result is false, the

--- a/src/Database/Traits/SoftDelete.php
+++ b/src/Database/Traits/SoftDelete.php
@@ -34,7 +34,7 @@ trait SoftDelete
             if ($model->methodExists('beforeRestore')) {
                 // Register the method as a listener with default priority
                 // to allow for complete control over the execution order
-                $model->bindEvent('model.beforeRestore', [$model, 'beforeRestore']);
+                $model->bindEventOnce('model.beforeRestore', [$model, 'beforeRestore']);
             }
             /**
              * @event model.beforeRestore
@@ -54,7 +54,7 @@ trait SoftDelete
             if ($model->methodExists('afterRestore')) {
                 // Register the method as a listener with default priority
                 // to allow for complete control over the execution order
-                $model->bindEvent('model.afterRestore', [$model, 'afterRestore']);
+                $model->bindEventOnce('model.afterRestore', [$model, 'afterRestore']);
             }
             /**
              * @event model.afterRestore

--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -65,7 +65,7 @@ trait Validation
             if ($model->methodExists('beforeValidate')) {
                 // Register the method as a listener with default priority
                 // to allow for complete control over the execution order
-                $model->bindEvent('model.beforeValidate', [$model, 'beforeValidate']);
+                $model->bindEventOnce('model.beforeValidate', [$model, 'beforeValidate']);
             }
 
             /**
@@ -87,7 +87,7 @@ trait Validation
             if ($model->methodExists('afterValidate')) {
                 // Register the method as a listener with default priority
                 // to allow for complete control over the execution order
-                $model->bindEvent('model.afterValidate', [$model, 'afterValidate']);
+                $model->bindEventOnce('model.afterValidate', [$model, 'afterValidate']);
             }
 
             /**

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -242,7 +242,7 @@ class Model extends Extendable implements ModelInterface, ArrayAccess, Arrayable
                     if ($model->methodExists($method)) {
                         // Register the method as a listener with default priority
                         // to allow for complete control over the execution order
-                        $model->bindEvent('model.' . $method, [$model, $method]);
+                        $model->bindEventOnce('model.' . $method, [$model, $method]);
                     }
                     // First listener that returns a non-null result will cancel the
                     // further propagation of the event; If that result is false, the


### PR DESCRIPTION
Fixes https://github.com/wintercms/winter/issues/1251 by replacing all instances of `bindEvent` inside a Laravel Model Event by `bindEventOnce`.

As mentioned in the issue above, there's still an edge case if the event is cancelled by another listener.