### PR TITLE
Add nestedToArray to treecollection

### DIFF
--- a/src/Database/Traits/NestedTree.php
+++ b/src/Database/Traits/NestedTree.php
@@ -54,6 +54,7 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
  *   $query->leaves(); // Filters as all final nodes without children.
  *   $query->getNested(); // Returns an eager loaded collection of results.
  *   $query->listsNested(); // Returns an indented array of key and value columns.
+ *   $query->nestedArray(); // Returns an nested array of key and values columns.
  *
  * Flat result access methods:
  *
@@ -516,6 +517,19 @@ trait NestedTree
     public function scopeGetNested($query)
     {
         return $query->get()->toNested();
+    }
+
+    /**
+     * Gets an nested array with values of a given columns.
+     *
+     * @param \Illuminate\Database\Query\Builder $query
+     * @param  mixed  $columns Model columns to return, either a string name of the role or an array of names.
+     * @param  string $key     Model column to use as key
+     * @return array
+     */
+    public function scopeNestedArray($query, $columns, $key = null)
+    {
+        return $query->get()->toNestedArray($columns, $key);
     }
 
     /**

--- a/src/Database/TreeCollection.php
+++ b/src/Database/TreeCollection.php
@@ -100,12 +100,12 @@ class TreeCollection extends Collection
     }
 
     /**
-     * Gets an nesteed array with values of a given columns.
+     * Gets an nested array with values of a given columns.
      * @param  array $values  Model columns to return
      * @param  string $key    Model column to use as key
      * @return array
      */
-    public function nestedToArray($values, $key = null)
+    public function toNestedArray($values, $key = null)
     {
         if (!is_array($values)) {
             $values = [$values];

--- a/src/Database/TreeCollection.php
+++ b/src/Database/TreeCollection.php
@@ -118,11 +118,13 @@ class TreeCollection extends Collection
             $result = [];
 
             foreach ($items as $item) {
+                $itemArray = [];
+
                 if ($key !== null) {
-                    $result[$item->{$key}] = $item->only($values);
+                    $itemArray[$item->{$key}] = $item->only($values);
                 }
                 else {
-                    $result[] = $item->only($values);
+                    $itemArray = array_merge($itemArray, $item->only($values));
                 }
 
                 /*
@@ -131,10 +133,16 @@ class TreeCollection extends Collection
                 $childItems = $item->getChildren();
                 if ($childItems->count() > 0) {
                     if ($key !== null) {
-                        $result[$item->{$key}]['children'] = $buildCollection($childItems);
+                        $itemArray[$item->{$key}]['children'] = $buildCollection($childItems);
                     } else {
-                        $result[]['children'] = $buildCollection($childItems);
+                        $itemArray = array_merge($itemArray, ['children' => $buildCollection($childItems)]);
                     }
+                }
+
+                if ($key !== null) {
+                    $result = $result + $itemArray;
+                } else {
+                    $result[] = $itemArray;
                 }
             }
 

--- a/src/Database/TreeCollection.php
+++ b/src/Database/TreeCollection.php
@@ -101,7 +101,7 @@ class TreeCollection extends Collection
 
     /**
      * Gets an nested array with values of a given columns.
-     * @param  array $values  Model columns to return
+     * @param  mixed  $values Model columns to return, either a string name of the role or an array of names.
      * @param  string $key    Model column to use as key
      * @return array
      */

--- a/src/Database/TreeCollection.php
+++ b/src/Database/TreeCollection.php
@@ -98,4 +98,53 @@ class TreeCollection extends Collection
         $rootItems = $this->toNested();
         return $buildCollection($rootItems);
     }
+
+    /**
+     * Gets an nesteed array with values of a given columns.
+     * @param  array $values  Model columns to return
+     * @param  string $key    Model column to use as key
+     * @return array
+     */
+    public function nestedToArray($values, $key = null)
+    {
+        if (!is_array($values)) {
+            $values = [$values];
+        }
+
+        /*
+         * Recursive helper function
+         */
+        $buildCollection = function ($items) use (&$buildCollection, $values, $key) {
+            $result = [];
+
+            foreach ($items as $item) {
+                if ($key !== null) {
+                    $result[$item->{$key}] = $item->only($values);
+                }
+                else {
+                    $result[] = $item->only($values);
+                }
+
+                /*
+                 * Add the children
+                 */
+                $childItems = $item->getChildren();
+                if ($childItems->count() > 0) {
+                    if ($key !== null) {
+                        $result[$item->{$key}]['children'] = $buildCollection($childItems);
+                    } else {
+                        $result[]['children'] = $buildCollection($childItems);
+                    }
+                }
+            }
+
+            return $result;
+        };
+
+        /*
+         * Build a nested collection
+         */
+        $rootItems = $this->toNested();
+        return $buildCollection($rootItems);
+    }
 }

--- a/tests/Database/Traits/NestedTreeTest.php
+++ b/tests/Database/Traits/NestedTreeTest.php
@@ -271,35 +271,35 @@ class NestedTreeTest extends DbTestCase
     {
         $array = CategoryNested::nestedArray('name');
         $this->assertEquals([
-            0 => [
+            [
                 "name" => "Category Orange",
                 "children" => [
-                    0 => [
+                    [
                         "name" => "Autumn Leaves",
                         "children" => [
-                            0 => [
+                            [
                                 "name" => "September",
                             ],
-                            1 => [
+                            [
                                 "name" => "October",
                             ],
-                            2 => [
+                            [
                                 "name" => "November",
                             ],
                         ],
                     ],
-                    1 => [
+                    [
                         "name" => "Summer Breeze",
                     ],
                 ],
             ],
-            1 => [
+            [
                 "name" => "Category Green",
                 "children" => [
-                    0 => [
+                    [
                         "name" => "Winter Snow",
                     ],
-                    1 => [
+                    [
                         "name" => "Spring Trees",
                     ],
                 ],
@@ -310,43 +310,43 @@ class NestedTreeTest extends DbTestCase
 
         $array = CategoryNested::nestedArray(['name', 'description']);
         $this->assertEquals([
-            0 => [
+            [
                 "name" => "Category Orange",
                 'description' => 'A root level test category',
                 "children" => [
-                    0 => [
+                    [
                         "name" => "Autumn Leaves",
                         'description' => 'Disccusion about the season of falling leaves.',
                         "children" => [
-                            0 => [
+                            [
                                 "name" => "September",
                                 'description' => 'The start of the fall season.'
                             ],
-                            1 => [
+                            [
                                 "name" => "October",
                                 'description' => 'The middle of the fall season.'
                             ],
-                            2 => [
+                            [
                                 "name" => "November",
                                 'description' => 'The end of the fall season.'
                             ],
                         ],
                     ],
-                    1 => [
+                    [
                         "name" => "Summer Breeze",
                         'description' => 'Disccusion about the wind at the ocean.'
                     ],
                 ],
             ],
-            1 => [
+            [
                 "name" => "Category Green",
                 'description' => 'A root level test category',
                 "children" => [
-                    0 => [
+                    [
                         "name" => "Winter Snow",
                         'description' => 'Disccusion about the frosty snow flakes.'
                     ],
-                    1 => [
+                    [
                         "name" => "Spring Trees",
                         'description' => 'Disccusion about the blooming gardens.'
                     ],
@@ -359,35 +359,35 @@ class NestedTreeTest extends DbTestCase
     {
         $array = CategoryNested::get()->toNestedArray('name');
         $this->assertEquals([
-            0 => [
+            [
                 "name" => "Category Orange",
                 "children" => [
-                    0 => [
+                    [
                         "name" => "Autumn Leaves",
                         "children" => [
-                            0 => [
+                            [
                                 "name" => "September",
                             ],
-                            1 => [
+                            [
                                 "name" => "October",
                             ],
-                            2 => [
+                            [
                                 "name" => "November",
                             ],
                         ],
                     ],
-                    1 => [
+                    [
                         "name" => "Summer Breeze",
                     ],
                 ],
             ],
-            1 => [
+            [
                 "name" => "Category Green",
                 "children" => [
-                    0 => [
+                    [
                         "name" => "Winter Snow",
                     ],
-                    1 => [
+                    [
                         "name" => "Spring Trees",
                     ],
                 ],
@@ -398,43 +398,43 @@ class NestedTreeTest extends DbTestCase
 
         $array = CategoryNested::get()->toNestedArray(['name', 'description']);
         $this->assertEquals([
-            0 => [
+            [
                 "name" => "Category Orange",
                 'description' => 'A root level test category',
                 "children" => [
-                    0 => [
+                    [
                         "name" => "Autumn Leaves",
                         'description' => 'Disccusion about the season of falling leaves.',
                         "children" => [
-                            0 => [
+                            [
                                 "name" => "September",
                                 'description' => 'The start of the fall season.'
                             ],
-                            1 => [
+                            [
                                 "name" => "October",
                                 'description' => 'The middle of the fall season.'
                             ],
-                            2 => [
+                            [
                                 "name" => "November",
                                 'description' => 'The end of the fall season.'
                             ],
                         ],
                     ],
-                    1 => [
+                    [
                         "name" => "Summer Breeze",
                         'description' => 'Disccusion about the wind at the ocean.'
                     ],
                 ],
             ],
-            1 => [
+            [
                 "name" => "Category Green",
                 'description' => 'A root level test category',
                 "children" => [
-                    0 => [
+                    [
                         "name" => "Winter Snow",
                         'description' => 'Disccusion about the frosty snow flakes.'
                     ],
-                    1 => [
+                    [
                         "name" => "Spring Trees",
                         'description' => 'Disccusion about the blooming gardens.'
                     ],

--- a/tests/Database/Traits/NestedTreeTest.php
+++ b/tests/Database/Traits/NestedTreeTest.php
@@ -138,6 +138,45 @@ class NestedTreeTest extends DbTestCase
                 ],
             ],
         ], $array);
+
+        CategoryNested::flushDuplicateCache();
+
+        $array = CategoryNested::nestedArray('name');
+        $this->assertEquals([
+            0 => [
+                "name" => "Category Orange",
+                "children" => [
+                    0 => [
+                        "name" => "Autumn Leaves",
+                        "children" => [
+                            0 => [
+                                "name" => "September",
+                            ],
+                            1 => [
+                                "name" => "October",
+                            ],
+                            2 => [
+                                "name" => "November",
+                            ],
+                        ],
+                    ],
+                    1 => [
+                        "name" => "Summer Breeze",
+                    ],
+                ],
+            ],
+            1 => [
+                "name" => "Category Green",
+                "children" => [
+                    0 => [
+                        "name" => "Winter Snow",
+                    ],
+                    1 => [
+                        "name" => "Spring Trees",
+                    ],
+                ],
+            ],
+        ], $array);
     }
 
     public function testToNestedArrayFromCollection()
@@ -174,6 +213,230 @@ class NestedTreeTest extends DbTestCase
                     ],
                     9 => [
                         "name" => "Spring Trees",
+                    ],
+                ],
+            ],
+        ], $array);
+
+        CategoryNested::flushDuplicateCache();
+
+        $array = CategoryNested::get()->toNestedArray(['name', 'description'], 'id');
+        $this->assertEquals([
+            1 => [
+                "name" => "Category Orange",
+                'description' => 'A root level test category',
+                "children" => [
+                    2 => [
+                        "name" => "Autumn Leaves",
+                        'description' => 'Disccusion about the season of falling leaves.',
+                        "children" => [
+                            3 => [
+                                "name" => "September",
+                                'description' => 'The start of the fall season.'
+                            ],
+                            4 => [
+                                "name" => "October",
+                                'description' => 'The middle of the fall season.'
+                            ],
+                            5 => [
+                                "name" => "November",
+                                'description' => 'The end of the fall season.'
+                            ],
+                        ],
+                    ],
+                    6 => [
+                        "name" => "Summer Breeze",
+                        'description' => 'Disccusion about the wind at the ocean.'
+                    ],
+                ],
+            ],
+            7 => [
+                "name" => "Category Green",
+                'description' => 'A root level test category',
+                "children" => [
+                    8 => [
+                        "name" => "Winter Snow",
+                        'description' => 'Disccusion about the frosty snow flakes.'
+                    ],
+                    9 => [
+                        "name" => "Spring Trees",
+                        'description' => 'Disccusion about the blooming gardens.'
+                    ],
+                ],
+            ],
+        ], $array);
+    }
+
+    public function testToNestedArrayWithoutKey()
+    {
+        $array = CategoryNested::nestedArray('name');
+        $this->assertEquals([
+            0 => [
+                "name" => "Category Orange",
+                "children" => [
+                    0 => [
+                        "name" => "Autumn Leaves",
+                        "children" => [
+                            0 => [
+                                "name" => "September",
+                            ],
+                            1 => [
+                                "name" => "October",
+                            ],
+                            2 => [
+                                "name" => "November",
+                            ],
+                        ],
+                    ],
+                    1 => [
+                        "name" => "Summer Breeze",
+                    ],
+                ],
+            ],
+            1 => [
+                "name" => "Category Green",
+                "children" => [
+                    0 => [
+                        "name" => "Winter Snow",
+                    ],
+                    1 => [
+                        "name" => "Spring Trees",
+                    ],
+                ],
+            ],
+        ], $array);
+
+        CategoryNested::flushDuplicateCache();
+
+        $array = CategoryNested::nestedArray(['name', 'description']);
+        $this->assertEquals([
+            0 => [
+                "name" => "Category Orange",
+                'description' => 'A root level test category',
+                "children" => [
+                    0 => [
+                        "name" => "Autumn Leaves",
+                        'description' => 'Disccusion about the season of falling leaves.',
+                        "children" => [
+                            0 => [
+                                "name" => "September",
+                                'description' => 'The start of the fall season.'
+                            ],
+                            1 => [
+                                "name" => "October",
+                                'description' => 'The middle of the fall season.'
+                            ],
+                            2 => [
+                                "name" => "November",
+                                'description' => 'The end of the fall season.'
+                            ],
+                        ],
+                    ],
+                    1 => [
+                        "name" => "Summer Breeze",
+                        'description' => 'Disccusion about the wind at the ocean.'
+                    ],
+                ],
+            ],
+            1 => [
+                "name" => "Category Green",
+                'description' => 'A root level test category',
+                "children" => [
+                    0 => [
+                        "name" => "Winter Snow",
+                        'description' => 'Disccusion about the frosty snow flakes.'
+                    ],
+                    1 => [
+                        "name" => "Spring Trees",
+                        'description' => 'Disccusion about the blooming gardens.'
+                    ],
+                ],
+            ],
+        ], $array);
+    }
+
+    public function testToNestedArrayFromCollectionWithoutKey()
+    {
+        $array = CategoryNested::get()->toNestedArray('name');
+        $this->assertEquals([
+            0 => [
+                "name" => "Category Orange",
+                "children" => [
+                    0 => [
+                        "name" => "Autumn Leaves",
+                        "children" => [
+                            0 => [
+                                "name" => "September",
+                            ],
+                            1 => [
+                                "name" => "October",
+                            ],
+                            2 => [
+                                "name" => "November",
+                            ],
+                        ],
+                    ],
+                    1 => [
+                        "name" => "Summer Breeze",
+                    ],
+                ],
+            ],
+            1 => [
+                "name" => "Category Green",
+                "children" => [
+                    0 => [
+                        "name" => "Winter Snow",
+                    ],
+                    1 => [
+                        "name" => "Spring Trees",
+                    ],
+                ],
+            ],
+        ], $array);
+
+        CategoryNested::flushDuplicateCache();
+
+        $array = CategoryNested::get()->toNestedArray(['name', 'description']);
+        $this->assertEquals([
+            0 => [
+                "name" => "Category Orange",
+                'description' => 'A root level test category',
+                "children" => [
+                    0 => [
+                        "name" => "Autumn Leaves",
+                        'description' => 'Disccusion about the season of falling leaves.',
+                        "children" => [
+                            0 => [
+                                "name" => "September",
+                                'description' => 'The start of the fall season.'
+                            ],
+                            1 => [
+                                "name" => "October",
+                                'description' => 'The middle of the fall season.'
+                            ],
+                            2 => [
+                                "name" => "November",
+                                'description' => 'The end of the fall season.'
+                            ],
+                        ],
+                    ],
+                    1 => [
+                        "name" => "Summer Breeze",
+                        'description' => 'Disccusion about the wind at the ocean.'
+                    ],
+                ],
+            ],
+            1 => [
+                "name" => "Category Green",
+                'description' => 'A root level test category',
+                "children" => [
+                    0 => [
+                        "name" => "Winter Snow",
+                        'description' => 'Disccusion about the frosty snow flakes.'
+                    ],
+                    1 => [
+                        "name" => "Spring Trees",
+                        'description' => 'Disccusion about the blooming gardens.'
                     ],
                 ],
             ],

--- a/tests/Database/Traits/NestedTreeTest.php
+++ b/tests/Database/Traits/NestedTreeTest.php
@@ -100,6 +100,86 @@ class NestedTreeTest extends DbTestCase
         ], $array);
     }
 
+    public function testToNestedArray()
+    {
+        $array = CategoryNested::nestedArray('name', 'id');
+        $this->assertEquals([
+            1 => [
+                "name" => "Category Orange",
+                "children" => [
+                    2 => [
+                        "name" => "Autumn Leaves",
+                        "children" => [
+                            3 => [
+                                "name" => "September",
+                            ],
+                            4 => [
+                                "name" => "October",
+                            ],
+                            5 => [
+                                "name" => "November",
+                            ],
+                        ],
+                    ],
+                    6 => [
+                        "name" => "Summer Breeze",
+                    ],
+                ],
+            ],
+            7 => [
+                "name" => "Category Green",
+                "children" => [
+                    8 => [
+                        "name" => "Winter Snow",
+                    ],
+                    9 => [
+                        "name" => "Spring Trees",
+                    ],
+                ],
+            ],
+        ], $array);
+    }
+
+    public function testToNestedArrayFromCollection()
+    {
+        $array = CategoryNested::get()->toNestedArray('name', 'id');
+        $this->assertEquals([
+            1 => [
+                "name" => "Category Orange",
+                "children" => [
+                    2 => [
+                        "name" => "Autumn Leaves",
+                        "children" => [
+                            3 => [
+                                "name" => "September",
+                            ],
+                            4 => [
+                                "name" => "October",
+                            ],
+                            5 => [
+                                "name" => "November",
+                            ],
+                        ],
+                    ],
+                    6 => [
+                        "name" => "Summer Breeze",
+                    ],
+                ],
+            ],
+            7 => [
+                "name" => "Category Green",
+                "children" => [
+                    8 => [
+                        "name" => "Winter Snow",
+                    ],
+                    9 => [
+                        "name" => "Spring Trees",
+                    ],
+                ],
+            ],
+        ], $array);
+    }
+
     public function seedSampleTree()
     {
         Model::unguard();


### PR DESCRIPTION
Added a new method to the `TreeCollection` class to obtain the collection in a nested array.

In order to add a tree view mode to the checkboxlist formwidget, I need to be able to get the collection items as a nested tree.

```php
$tree = new Winter\Test\Models\Channel;
$tree->all();  // Winter\Storm\Database\TreeCollection

$tree->nestedArray(title', 'id'); 
// or 
$tree->all()->toNestedArray('title', 'id');
// return an nested array
[
    1 => [
      "title" => "Channel Orange",
      "children" => [
        2 => [
          "title" => "Autumn Leaves",
          "children" => [
            3 => [
              "title" => "September",
            ],
            4 => [
              "title" => "Winter",
            ],
            5 => [
              "title" => "November",
            ],
          ],
        ],
        6 => [
          "title" => "Summer Breeze",
        ],
      ],
    ],
    7 => [
      "title" => "Channel Green",
      "children" => [
        8 => [
          "title" => "Winter Snow",
        ],
        9 => [
          "title" => "Spring Trees",
        ],
      ],
    ],
  ]
  ```
  
Can be used with multiple column names to be returned in the array:
  ```php
 $tree->nestedArray(['title', 'description'], 'id'),
 // or 
$tree->all()->toNestedArray(['title', 'description'], 'id');
  ```
  Can also be used without key : 
  ```php
$tree->nestedArray(title'); 
// or 
$tree->all()->nestedToArray('title');
  
$tree->nestedArray(['title', 'description']),
// or 
$tree->all()->nestedToArray(['title', 'description']);
```