### PR TITLE
Add default user agent

### DIFF
--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -275,6 +275,7 @@ class Http
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
+        curl_setopt($curl, CURLOPT_USERAGENT, 'Winter Storm');
 
         if (defined('CURLOPT_FOLLOWLOCATION') && !ini_get('open_basedir')) {
             curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true);


### PR DESCRIPTION
Some hosts will not accept GET requests if no User Agent is defined.