### PR TITLE
Add model:prune console command

### DIFF
--- a/src/Database/Console/PruneCommand.php
+++ b/src/Database/Console/PruneCommand.php
@@ -28,12 +28,7 @@ class PruneCommand extends BasePruneCommand
             throw new InvalidArgumentException('The --models and --except options cannot be combined.');
         }
 
-        $paths = [
-            base_path() . '/modules' => '/*/models',
-            plugins_path() => '/*/*/models',
-        ];
-
-        return File::findModels($paths)
+        return $this->findModels()
             ->when(! empty($except), function ($models) use ($except) {
                 return $models->reject(function ($model) use ($except) {
                     return in_array($model, $except);
@@ -43,6 +38,31 @@ class PruneCommand extends BasePruneCommand
             })->filter(function ($model) {
                 return class_exists($model);
             })->values();
+    }
+
+    protected function findModels()
+    {
+        /**
+         * @event system.console.model.prune.findModels
+         * Give the opportunity to return a collection of Models to prune.
+         *
+         * Example usage:
+         *
+         *     Event::listen('system.console.model.prune.findModels', function () {
+         *         return collect(['example model' => '\System\Models\File']);
+         *     });
+         *
+         */
+        $models = \Event::fire('system.console.model.prune.findModels', [$this], true);
+        if ($models instanceof \Illuminate\Support\Collection) {
+            return $models;
+        }
+
+        $paths = [
+            base_path() . '/modules' => '/*/models',
+            plugins_path() => '/*/*/models',
+        ];
+        return File::findModels($paths);
     }
 
     /**

--- a/src/Database/Console/PruneCommand.php
+++ b/src/Database/Console/PruneCommand.php
@@ -6,7 +6,7 @@ use Exception;
 use Illuminate\Database\Console\PruneCommand as BasePruneCommand;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Prunable;
-use Illuminate\Support\Facades\Event;
+use Winter\Storm\Support\Facades\Event;
 use Winter\Storm\Support\Facades\File;
 
 class PruneCommand extends BasePruneCommand

--- a/src/Database/Console/PruneCommand.php
+++ b/src/Database/Console/PruneCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Winter\Storm\Database\Console;
+
+use Illuminate\Database\Console\PruneCommand as BasePruneCommand;
+use Illuminate\Database\Eloquent\MassPrunable;
+use Illuminate\Database\Eloquent\Prunable;
+use Winter\Storm\Support\Facades\File;
+
+class PruneCommand extends BasePruneCommand
+{
+    /**
+     * Determine the models that should be pruned.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function models()
+    {
+        if (! empty($models = $this->option('model'))) {
+            return collect($models)->filter(function ($model) {
+                return class_exists($model);
+            })->values();
+        }
+
+        $except = $this->option('except');
+
+        if (! empty($models) && ! empty($except)) {
+            throw new InvalidArgumentException('The --models and --except options cannot be combined.');
+        }
+
+        $paths = [
+            base_path() . '/modules' => '/*/models',
+            plugins_path() => '/*/*/models',
+        ];
+
+        return File::findModels($paths)
+            ->when(! empty($except), function ($models) use ($except) {
+                return $models->reject(function ($model) use ($except) {
+                    return in_array($model, $except);
+                });
+            })->filter(function ($model) {
+                return $this->isPrunable($model);
+            })->filter(function ($model) {
+                return class_exists($model);
+            })->values();
+    }
+
+    /**
+     * Determine if the given model class is prunable.
+     *
+     * @param  string  $model
+     * @return bool
+     */
+    protected function isPrunable($model)
+    {
+        try {
+            $uses = class_uses_recursive($model);
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return in_array(Prunable::class, $uses) || in_array(MassPrunable::class, $uses);
+    }
+}

--- a/src/Database/Console/PruneCommand.php
+++ b/src/Database/Console/PruneCommand.php
@@ -5,6 +5,7 @@ namespace Winter\Storm\Database\Console;
 use Illuminate\Database\Console\PruneCommand as BasePruneCommand;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Support\Facades\Event;
 use Winter\Storm\Support\Facades\File;
 
 class PruneCommand extends BasePruneCommand
@@ -53,7 +54,7 @@ class PruneCommand extends BasePruneCommand
          *     });
          *
          */
-        $models = \Event::fire('system.console.model.prune.findModels', [$this], true);
+        $models = Event::fire('system.console.model.prune.findModels', [$this], true);
         if ($models instanceof \Illuminate\Support\Collection) {
             return $models;
         }

--- a/src/Database/Console/PruneCommand.php
+++ b/src/Database/Console/PruneCommand.php
@@ -2,6 +2,7 @@
 
 namespace Winter\Storm\Database\Console;
 
+use Exception;
 use Illuminate\Database\Console\PruneCommand as BasePruneCommand;
 use Illuminate\Database\Eloquent\MassPrunable;
 use Illuminate\Database\Eloquent\Prunable;
@@ -11,9 +12,7 @@ use Winter\Storm\Support\Facades\File;
 class PruneCommand extends BasePruneCommand
 {
     /**
-     * Determine the models that should be pruned.
-     *
-     * @return \Illuminate\Support\Collection
+     * {@inheritDoc}
      */
     protected function models()
     {
@@ -24,10 +23,6 @@ class PruneCommand extends BasePruneCommand
         }
 
         $except = $this->option('except');
-
-        if (! empty($models) && ! empty($except)) {
-            throw new InvalidArgumentException('The --models and --except options cannot be combined.');
-        }
 
         return $this->findModels()
             ->when(! empty($except), function ($models) use ($except) {
@@ -76,7 +71,7 @@ class PruneCommand extends BasePruneCommand
     {
         try {
             $uses = class_uses_recursive($model);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             return false;
         }
 

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -613,8 +613,7 @@ class Filesystem extends FilesystemBase
                 ->map(function ($model) use ($path) {
                     $modelPath = str_replace(['/', '.php'], ['\\', ''], Str::after($model->getRealPath(), realpath($path).DIRECTORY_SEPARATOR));
                     return ucwords($modelPath, '\\');
-                })
-            );
+                }));
         }
 
         return $models;

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -609,12 +609,12 @@ class Filesystem extends FilesystemBase
 
         foreach ($paths as $path => $pattern) {
             $models = $models->merge(collect(Finder::create()
-                ->in($path . $pattern)
-                ->files()->name('/^[A-Z]{1}.+\.php$/')
-            )->map(function ($model) use ($path) {
-                $modelPath = str_replace(['/', '.php'], ['\\', ''], Str::after($model->getRealPath(), realpath($path).DIRECTORY_SEPARATOR));
-                return ucwords($modelPath, '\\');
-            }));
+                ->in($path . $pattern)->files()->name('/^[A-Z]{1}.+\.php$/'))
+                ->map(function ($model) use ($path) {
+                    $modelPath = str_replace(['/', '.php'], ['\\', ''], Str::after($model->getRealPath(), realpath($path).DIRECTORY_SEPARATOR));
+                    return ucwords($modelPath, '\\');
+                })
+            );
         }
 
         return $models;

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -2,11 +2,14 @@
 
 use DirectoryIterator;
 use FilesystemIterator;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Filesystem\Filesystem as FilesystemBase;
 use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use ReflectionClass;
+use Symfony\Component\Finder\Finder;
+use Winter\Storm\Support\Collection;
 use Winter\Storm\Support\Facades\Config;
 
 /**
@@ -592,5 +595,31 @@ class Filesystem extends FilesystemBase
         }
 
         return false;
+    }
+
+    /**
+     * Find all Database Models in provided paths with patterns.
+     *
+     * @param array $paths      The associative array of $path => $pattern to search for.
+     * @return Collection       A collection of Database Models found.
+     */
+    public function findModels(array $paths): Collection
+    {
+        $models = collect();
+
+        foreach ($paths as $path => $pattern) {
+            $models = $models->merge(collect(Finder::create()
+                ->in($path . $pattern)
+                ->files()->name('/^[A-Z]{1}.+\.php$/')
+            )->map(function ($model) use ($path) {
+                return str_replace(
+                    ['/', '.php'],
+                    ['\\', ''],
+                    Str::after($model->getRealPath(), realpath($path).DIRECTORY_SEPARATOR)
+                );
+            }));
+        }
+
+        return $models;
     }
 }

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 use InvalidArgumentException;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
-use Winter\Storm\Support\Collection;
+use Illuminate\Support\Collection;
 use Winter\Storm\Support\Facades\Config;
 
 /**

--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -612,11 +612,8 @@ class Filesystem extends FilesystemBase
                 ->in($path . $pattern)
                 ->files()->name('/^[A-Z]{1}.+\.php$/')
             )->map(function ($model) use ($path) {
-                return str_replace(
-                    ['/', '.php'],
-                    ['\\', ''],
-                    Str::after($model->getRealPath(), realpath($path).DIRECTORY_SEPARATOR)
-                );
+                $modelPath = str_replace(['/', '.php'], ['\\', ''], Str::after($model->getRealPath(), realpath($path).DIRECTORY_SEPARATOR));
+                return ucwords($modelPath, '\\');
             }));
         }
 

--- a/src/Foundation/Providers/ArtisanServiceProvider.php
+++ b/src/Foundation/Providers/ArtisanServiceProvider.php
@@ -18,6 +18,7 @@ class ArtisanServiceProvider extends ArtisanServiceProviderBase
         'ClearCompiled'         => \Winter\Storm\Foundation\Console\ClearCompiledCommand::class,
         'ConfigCache'           => \Illuminate\Foundation\Console\ConfigCacheCommand::class,
         'ConfigClear'           => \Illuminate\Foundation\Console\ConfigClearCommand::class,
+        'DbPrune'               => \Illuminate\Database\Console\PruneCommand::class,
         'Down'                  => \Illuminate\Foundation\Console\DownCommand::class,
         'Environment'           => \Illuminate\Foundation\Console\EnvironmentCommand::class,
         'EventCache'            => \Illuminate\Foundation\Console\EventCacheCommand::class,
@@ -49,7 +50,6 @@ class ArtisanServiceProvider extends ArtisanServiceProviderBase
         // @TODO: Assess for inclusion
         // 'ClearResets' => ClearResetsCommand::class,
         // 'Db' => DbCommand::class,
-        // 'DbPrune' => PruneCommand::class,
         // 'DbWipe' => WipeCommand::class,
         // 'OptimizeClear' => OptimizeClearCommand::class,
         // 'QueueClear' => QueueClearCommand::class,

--- a/src/Support/Facades/File.php
+++ b/src/Support/Facades/File.php
@@ -21,6 +21,7 @@ use Winter\Storm\Support\Facade;
  * @method static string basename(string $path)
  * @method static string dirname(string $path)
  * @method static string extension(string $path)
+ * @method static \Illuminate\Support\Collection findModels(array $paths)
  * @method static string type(string $path)
  * @method static string|false mimeType(string $path)
  * @method static int size(string $path)


### PR DESCRIPTION
To show only active plugins, we need to add an event listener in Winter core as shown below:

```php
Event::listen('system.console.model.prune.findModels', function () {
    $models = [];
    $pm = \System\Classes\PluginManager::instance();
 
    $modulesModels = File::findModels([base_path() . '/modules' => '/*/models']);
    $models[] = $modulesModels->all();
 
    $pluginsPaths = collect($pm->getPlugins())->map(function ($plugin) use ($pm) { 
        return $pm->getPluginPath($plugin);
    })->filter(function ($path) {
        return File::exists($path . '/models');
    })->each(function ($path) use (&$models) {
        $modelPaths = Finder::create()->in($path . '/models')->files()->name('/^[A-Z]{1}.+\.php$/');
        $models[] = collect($modelPaths)->map(function ($model) {
            $modelPath = str_replace(['/', '.php'], ['\\', ''], Str::after($model->getRealPath(), plugins_path().DIRECTORY_SEPARATOR));
            return ucwords($modelPath, '\\');
        })->all();
    });
 
    return collect($models)->flatten();
});

```