### PR TITLE
Unset event handler when halting

### DIFF
--- a/src/Support/Traits/Emitter.php
+++ b/src/Support/Traits/Emitter.php
@@ -162,6 +162,7 @@ trait Emitter
                     continue;
                 }
                 if ($halt) {
+                    unset($this->emitterSingleEventCollection[$event]);
                     return $response;
                 }
                 $result[] = $response;

--- a/tests/Support/EmitterTest.php
+++ b/tests/Support/EmitterTest.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Events\QueuedClosure;
 
+include_once __DIR__.'/../fixtures/events/EventTest.php';
+
 class EmitterTest extends TestCase
 {
     /**
@@ -57,6 +59,24 @@ class EmitterTest extends TestCase
         $emitter->fireEvent('event.test');
         $emitter->fireEvent('event.test');
         $emitter->fireEvent('event.test');
+
+        $this->assertEquals(2, $result);
+    }
+
+    public function testHaltingBindOnce()
+    {
+        $emitter = $this->traitObject;
+        $result = 1;
+
+        $callback = function () use (&$result) {
+            $result++;
+            return false;
+        };
+
+        $emitter->bindEventOnce('event.test', $callback);
+        $emitter->fireEvent('event.test', halt:true);
+        $emitter->fireEvent('event.test', halt:true);
+        $emitter->fireEvent('event.test', halt:true);
 
         $this->assertEquals(2, $result);
     }


### PR DESCRIPTION
This is supposed to run once, make it so in all cases.