### PR TITLE
Fix for dynamic methods defined as [class, method]

### DIFF
--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -2,7 +2,6 @@
 
 namespace Winter\Storm\Database\Concerns;
 
-use Closure;
 use InvalidArgumentException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -793,10 +792,11 @@ trait HasRelationships
             $object = $this->extensionData['extensions'][$extension];
             $method = new \ReflectionMethod($object, $name);
         } elseif (isset($this->extensionData['dynamicMethods'][$name])) {
-            if (is_array($this->extensionData['dynamicMethods'][$name])) {
-                $method = new \ReflectionMethod(...$this->extensionData['dynamicMethods'][$name]);
+            $dynamicMethod = $this->extensionData['dynamicMethods'][$name];
+            if (is_array($dynamicMethod)) {
+                $method = new \ReflectionMethod(...$dynamicMethod);
             } else {
-                $method = new \ReflectionFunction($this->extensionData['dynamicMethods'][$name]->getClosure());
+                $method = new \ReflectionFunction($dynamicMethod->getClosure());
             }
         } else {
             if (!isset(static::$resolvedNonRelationMethods[static::class])) {

--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -2,6 +2,7 @@
 
 namespace Winter\Storm\Database\Concerns;
 
+use Closure;
 use InvalidArgumentException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;

--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -792,7 +792,11 @@ trait HasRelationships
             $object = $this->extensionData['extensions'][$extension];
             $method = new \ReflectionMethod($object, $name);
         } elseif (isset($this->extensionData['dynamicMethods'][$name])) {
-            $method = new \ReflectionFunction($this->extensionData['dynamicMethods'][$name]->getClosure());
+            if (is_array($this->extensionData['dynamicMethods'][$name])) {
+                $method = new \ReflectionMethod(...$this->extensionData['dynamicMethods'][$name]);
+            } else {
+                $method = new \ReflectionFunction($this->extensionData['dynamicMethods'][$name]->getClosure());
+            }
         } else {
             if (!isset(static::$resolvedNonRelationMethods[static::class])) {
                 static::$resolvedNonRelationMethods[static::class] = [$name];

--- a/tests/Database/Concerns/HasRelationshipsTest.php
+++ b/tests/Database/Concerns/HasRelationshipsTest.php
@@ -48,17 +48,27 @@ class HasRelationshipsTest extends DbTestCase
         $this->assertFalse($author->hasRelation('invalid'));
     }
 
-    public function testDynamicRelationMethods()
+    public function testRelationDynamicMethods()
+    {
+        $author = new Author();
+
+        $author->addDynamicMethod('dynamicClassMethodFromArray', [$author, 'messages']);
+        $this->assertTrue($author->hasRelation('dynamicClassMethodFromArray'));
+        $this->assertEquals('hasMany', $author->getRelationType('dynamicClassMethodFromArray'));
+    }
+
+    public function testNonRelationDynamicMethods()
     {
         $author = new Author();
 
         $author->addDynamicMethod('dynamicMethodAsClosure', function () {
         });
-        $author->addDynamicMethod('dynamicStaticClassMethodFromArray', [Author::class, 'hasDatabaseTable']);
-        $author->addDynamicMethod('dynamicClassMethodFromArray', [$author, 'isDatabaseReady']);
-
         $this->assertFalse($author->hasRelation('dynamicMethodAsClosure'));
+
+        $author->addDynamicMethod('dynamicStaticClassMethodFromArray', [Author::class, 'hasDatabaseTable']);
         $this->assertFalse($author->hasRelation('dynamicStaticClassMethodFromArray'));
+
+        $author->addDynamicMethod('dynamicClassMethodFromArray', [$author, 'isDatabaseReady']);
         $this->assertFalse($author->hasRelation('dynamicClassMethodFromArray'));
     }
 

--- a/tests/Database/Concerns/HasRelationshipsTest.php
+++ b/tests/Database/Concerns/HasRelationshipsTest.php
@@ -48,16 +48,20 @@ class HasRelationshipsTest extends DbTestCase
         $this->assertFalse($author->hasRelation('invalid'));
     }
 
-    public function testDynamicRelationMethod()
+    public function testDynamicRelationMethods()
     {
         $author = new Author();
 
         $author->addDynamicMethod('dynamicMethodAsClosure', function () {
         });
-        $author->addDynamicMethod('dynamicClassMethod', [$author, 'isDatabaseReady']);
+        $author->addDynamicMethod('dynamicStaticClassMethod', 'Author::hasDatabaseTable');
+        $author->addDynamicMethod('dynamicClassMethodFromArray', [$author, 'isDatabaseReady']);
+        $author->addDynamicMethod('dynamicStaticClassMethodFromArray', [Author::class, 'hasDatabaseTable']);
 
         $this->assertFalse($author->hasRelation('dynamicMethodAsClosure'));
-        $this->assertFalse($author->hasRelation('dynamicClassMethod'));
+        $this->assertFalse($author->hasRelation('dynamicStaticClassMethod'));
+        $this->assertFalse($author->hasRelation('dynamicClassMethodFromArray'));
+        $this->assertFalse($author->hasRelation('dynamicStaticClassMethodFromArray'));
     }
 
     public function testGetRelationType()

--- a/tests/Database/Concerns/HasRelationshipsTest.php
+++ b/tests/Database/Concerns/HasRelationshipsTest.php
@@ -48,6 +48,17 @@ class HasRelationshipsTest extends DbTestCase
         $this->assertFalse($author->hasRelation('invalid'));
     }
 
+    public function testDynamicRelationMethod()
+    {
+        $author = new Author();
+
+        $author->addDynamicMethod('dynamicMethodAsClosure', function () {});
+        $author->addDynamicMethod('dynamicClassMethod', [$author, 'isDatabaseReady']);
+
+        $this->assertFalse($author->hasRelation('dynamicMethodAsClosure'));
+        $this->assertFalse($author->hasRelation('dynamicClassMethod'));
+    }
+
     public function testGetRelationType()
     {
         $author = new Author();

--- a/tests/Database/Concerns/HasRelationshipsTest.php
+++ b/tests/Database/Concerns/HasRelationshipsTest.php
@@ -52,7 +52,8 @@ class HasRelationshipsTest extends DbTestCase
     {
         $author = new Author();
 
-        $author->addDynamicMethod('dynamicMethodAsClosure', function () {});
+        $author->addDynamicMethod('dynamicMethodAsClosure', function () {
+        });
         $author->addDynamicMethod('dynamicClassMethod', [$author, 'isDatabaseReady']);
 
         $this->assertFalse($author->hasRelation('dynamicMethodAsClosure'));

--- a/tests/Database/Concerns/HasRelationshipsTest.php
+++ b/tests/Database/Concerns/HasRelationshipsTest.php
@@ -54,14 +54,12 @@ class HasRelationshipsTest extends DbTestCase
 
         $author->addDynamicMethod('dynamicMethodAsClosure', function () {
         });
-        $author->addDynamicMethod('dynamicStaticClassMethod', 'Author::hasDatabaseTable');
-        $author->addDynamicMethod('dynamicClassMethodFromArray', [$author, 'isDatabaseReady']);
         $author->addDynamicMethod('dynamicStaticClassMethodFromArray', [Author::class, 'hasDatabaseTable']);
+        $author->addDynamicMethod('dynamicClassMethodFromArray', [$author, 'isDatabaseReady']);
 
         $this->assertFalse($author->hasRelation('dynamicMethodAsClosure'));
-        $this->assertFalse($author->hasRelation('dynamicStaticClassMethod'));
-        $this->assertFalse($author->hasRelation('dynamicClassMethodFromArray'));
         $this->assertFalse($author->hasRelation('dynamicStaticClassMethodFromArray'));
+        $this->assertFalse($author->hasRelation('dynamicClassMethodFromArray'));
     }
 
     public function testGetRelationType()


### PR DESCRIPTION
The following breaks HasRelationships concern:
```php
$model->addDynamicMethod('myMethod', [static::class, 'myMethod']);
```