### PR TITLE
Fix Syntax Error in CAST Statement for Postgres Attachment Count Query

### DIFF
--- a/src/Database/Relations/Concerns/AttachOneOrMany.php
+++ b/src/Database/Relations/Concerns/AttachOneOrMany.php
@@ -71,7 +71,7 @@ trait AttachOneOrMany
         if ($parentQuery->getQuery()->from == $query->getQuery()->from) {
             $query = $this->getRelationExistenceQueryForSelfJoin($query, $parentQuery, $columns);
         } else {
-            $grammar = $this->query->getGrammar();
+            $grammar = $query->getGrammar();
             $query->select($columns)->whereRaw(sprintf(
                 '%s = %s',
                 $grammar->wrap($this->getExistenceCompareKey()),

--- a/src/Database/Relations/Concerns/AttachOneOrMany.php
+++ b/src/Database/Relations/Concerns/AttachOneOrMany.php
@@ -70,17 +70,17 @@ trait AttachOneOrMany
     {
         if ($parentQuery->getQuery()->from == $query->getQuery()->from) {
             $query = $this->getRelationExistenceQueryForSelfJoin($query, $parentQuery, $columns);
-        }
-        else {
+        } else {
             $grammar = $this->query->getGrammar();
-            $key = DbDongle::cast($grammar->wrap($this->getQualifiedParentKeyName()), 'TEXT');
-
-            $query = $query->select($columns)->whereRaw($grammar->wrap($this->getExistenceCompareKey()) . '=' . $key);
+            $query->select($columns)->whereRaw(sprintf(
+                '%s = %s',
+                $grammar->wrap($this->getExistenceCompareKey()),
+                DbDongle::cast($grammar->wrap($this->getQualifiedParentKeyName()), 'TEXT')
+            ));
         }
 
-        $query = $query->where($this->morphType, $this->morphClass);
-
-        return $query->where('field', $this->fieldName);
+        return $query->where($this->morphType, $this->morphClass)
+            ->where('field', $this->fieldName);
     }
 
     /**
@@ -93,16 +93,19 @@ trait AttachOneOrMany
      */
     public function getRelationExistenceQueryForSelfRelation(Builder $query, Builder $parentQuery, $columns = ['*'])
     {
+        $hash = $this->getRelationCountHash();
+        $grammar = $query->getGrammar();
+        
         $query->select($columns)->from(
-            $query->getModel()->getTable().' as '.$hash = $this->getRelationCountHash()
+            $query->getModel()->getTable() . ' as ' . $hash
         );
-
         $query->getModel()->setTable($hash);
 
-        $grammar = $query->getGrammar();
-        $key = DbDongle::cast($grammar->wrap($this->getQualifiedParentKeyName()), 'TEXT');
-
-        return $query->whereRaw($grammar->wrap($hash.'.'.$this->getForeignKeyName()) . '=' . $key);
+        return $query->whereRaw(sprintf(
+            '%s = %s',
+            $grammar->wrap($hash . '.' . $this->getForeignKeyName()),
+            DbDongle::cast($grammar->wrap($this->getQualifiedParentKeyName()), 'TEXT')
+        ));
     }
 
     /**

--- a/src/Database/Relations/Concerns/AttachOneOrMany.php
+++ b/src/Database/Relations/Concerns/AttachOneOrMany.php
@@ -72,9 +72,10 @@ trait AttachOneOrMany
             $query = $this->getRelationExistenceQueryForSelfJoin($query, $parentQuery, $columns);
         }
         else {
-            $key = DbDongle::cast($this->getQualifiedParentKeyName(), 'TEXT');
+            $grammar = $this->query->getGrammar();
+            $key = DbDongle::cast($grammar->wrap($this->getQualifiedParentKeyName()), 'TEXT');
 
-            $query = $query->select($columns)->whereColumn($this->getExistenceCompareKey(), '=', $key);
+            $query = $query->select($columns)->whereRaw($grammar->wrap($this->getExistenceCompareKey()) . '=' . $key);
         }
 
         $query = $query->where($this->morphType, $this->morphClass);
@@ -98,9 +99,10 @@ trait AttachOneOrMany
 
         $query->getModel()->setTable($hash);
 
-        $key = DbDongle::cast($this->getQualifiedParentKeyName(), 'TEXT');
+        $grammar = $query->getGrammar();
+        $key = DbDongle::cast($grammar->wrap($this->getQualifiedParentKeyName()), 'TEXT');
 
-        return $query->whereColumn($hash.'.'.$this->getForeignKeyName(), '=', $key);
+        return $query->whereRaw($grammar->wrap($hash.'.'.$this->getForeignKeyName()) . '=' . $key);
     }
 
     /**


### PR DESCRIPTION
When querying the Postgres database, the attachment count query was generated as follows:

`select count(*) 
from "system_files" 
where "system_files"."attachment_id" = "CAST(some_table"."id" as "TEXT)" 
and "system_files"."attachment_type" = Some\Model 
and "field" = images) as "images_count"`

This query results in a syntax error due to an incorrect placement of double quotes in the CAST statement.

Changes Made:
Fixed the syntax error by properly wrapping keys before casting.
Used raw queries to prevent issues with double wrapping of keys.
