### PR TITLE
Improve PHP 8.4 support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli-bookworm
+FROM php:8.4-cli-bookworm
 
 # Install PHP extensions
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/debian
 {
-    "name": "Winter Storm on PHP 8.3",
+    "name": "Winter Storm on PHP 8.4",
     "build": {
         "dockerfile": "./Dockerfile",
         "context": "."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       max-parallel: 6
       matrix:
         operatingSystem: [ubuntu-latest, windows-latest]
-        phpVersion: ['8.0', '8.1', '8.2', '8.3']
+        phpVersion: ['8.0', '8.1', '8.2', '8.3', '8.4']
       fail-fast: false
     runs-on: ${{ matrix.operatingSystem }}
     name: ${{ matrix.operatingSystem }} / PHP ${{ matrix.phpVersion }}

--- a/src/Argon/Argon.php
+++ b/src/Argon/Argon.php
@@ -55,7 +55,7 @@ class Argon extends Carbon
      */
     public static function createFromFormatWithCurrentLocale(
         string $format,
-        string|null $time = null,
+        ?string $time = null,
         \DateTimeZone|string|false|null $timezone = null
     ): static|false {
         if (is_string($time)) {

--- a/src/Argon/Argon.php
+++ b/src/Argon/Argon.php
@@ -55,7 +55,7 @@ class Argon extends Carbon
      */
     public static function createFromFormatWithCurrentLocale(
         string $format,
-        string $time = null,
+        string|null $time = null,
         \DateTimeZone|string|false|null $timezone = null
     ): static|false {
         if (is_string($time)) {

--- a/src/Auth/AuthenticationException.php
+++ b/src/Auth/AuthenticationException.php
@@ -29,7 +29,7 @@ class AuthenticationException extends ApplicationException
      * @param int $code Error code.
      * @param Exception $previous Previous exception.
      */
-    public function __construct($message = "", $code = 0, Exception|null $previous = null)
+    public function __construct($message = "", $code = 0, ?Exception $previous = null)
     {
         $this->errorMessage = Lang::get('backend::lang.auth.invalid_login');
 

--- a/src/Auth/AuthenticationException.php
+++ b/src/Auth/AuthenticationException.php
@@ -29,7 +29,7 @@ class AuthenticationException extends ApplicationException
      * @param int $code Error code.
      * @param Exception $previous Previous exception.
      */
-    public function __construct($message = "", $code = 0, Exception $previous = null)
+    public function __construct($message = "", $code = 0, Exception|null $previous = null)
     {
         $this->errorMessage = Lang::get('backend::lang.auth.invalid_login');
 

--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -658,7 +658,10 @@ trait HasRelationships
         });
 
         // If we're dealing with a closure, we're likely dealing with an extension. We'll need to go deeper!
-        if (str_contains($caller['function'], '{closure}')) {
+        if (
+            str_contains($caller['function'], '{closure:') // PHP 8.4+
+            || str_contains($caller['function'], '{closure}') // <= PHP 8.3
+        ) {
             [$stepOne, $stepTwo] = array_slice($trace, $currentKey + 1, 2);
 
             if ($stepOne['function'] !== 'call_user_func_array') {

--- a/src/Exception/ApplicationException.php
+++ b/src/Exception/ApplicationException.php
@@ -19,7 +19,7 @@ class ApplicationException extends ExceptionBase
      * @param int $code Error code.
      * @param Exception $previous Previous exception.
      */
-    public function __construct($message = "", $code = 0, Exception $previous = null)
+    public function __construct($message = "", $code = 0, Exception|null $previous = null)
     {
         $message = HtmlBuilder::clean($message);
 

--- a/src/Exception/ApplicationException.php
+++ b/src/Exception/ApplicationException.php
@@ -19,7 +19,7 @@ class ApplicationException extends ExceptionBase
      * @param int $code Error code.
      * @param Exception $previous Previous exception.
      */
-    public function __construct($message = "", $code = 0, Exception|null $previous = null)
+    public function __construct($message = "", $code = 0, ?Exception $previous = null)
     {
         $message = HtmlBuilder::clean($message);
 

--- a/src/Exception/ExceptionBase.php
+++ b/src/Exception/ExceptionBase.php
@@ -51,7 +51,7 @@ class ExceptionBase extends Exception
      * @param int $code Error code.
      * @param Throwable $previous Previous exception.
      */
-    public function __construct($message = "", $code = 0, Throwable|null $previous = null)
+    public function __construct($message = "", $code = 0, ?Throwable $previous = null)
     {
         if ($this->className === null) {
             $this->className = get_called_class();

--- a/src/Exception/ExceptionBase.php
+++ b/src/Exception/ExceptionBase.php
@@ -51,7 +51,7 @@ class ExceptionBase extends Exception
      * @param int $code Error code.
      * @param Throwable $previous Previous exception.
      */
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    public function __construct($message = "", $code = 0, Throwable|null $previous = null)
     {
         if ($this->className === null) {
             $this->className = get_called_class();

--- a/src/Exception/SystemException.php
+++ b/src/Exception/SystemException.php
@@ -19,7 +19,7 @@ class SystemException extends ExceptionBase
      * @param int $code Error code.
      * @param Throwable $previous Previous exception.
      */
-    public function __construct($message = "", $code = 0, Throwable|null $previous = null)
+    public function __construct($message = "", $code = 0, ?Throwable $previous = null)
     {
         $message = HtmlBuilder::clean($message);
 

--- a/src/Exception/SystemException.php
+++ b/src/Exception/SystemException.php
@@ -19,7 +19,7 @@ class SystemException extends ExceptionBase
      * @param int $code Error code.
      * @param Throwable $previous Previous exception.
      */
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    public function __construct($message = "", $code = 0, Throwable|null $previous = null)
     {
         $message = HtmlBuilder::clean($message);
 

--- a/src/Halcyon/Datasource/Resolver.php
+++ b/src/Halcyon/Datasource/Resolver.php
@@ -31,7 +31,7 @@ class Resolver implements ResolverInterface
     /**
      * @inheritDoc
      */
-    public function datasource(string|null $name = null): DatasourceInterface
+    public function datasource(?string $name = null): DatasourceInterface
     {
         if (is_null($name)) {
             $name = $this->getDefaultDatasource();

--- a/src/Halcyon/Datasource/Resolver.php
+++ b/src/Halcyon/Datasource/Resolver.php
@@ -31,7 +31,7 @@ class Resolver implements ResolverInterface
     /**
      * @inheritDoc
      */
-    public function datasource(string $name = null): DatasourceInterface
+    public function datasource(string|null $name = null): DatasourceInterface
     {
         if (is_null($name)) {
             $name = $this->getDefaultDatasource();

--- a/src/Halcyon/Datasource/ResolverInterface.php
+++ b/src/Halcyon/Datasource/ResolverInterface.php
@@ -14,7 +14,7 @@ interface ResolverInterface
      *
      * @throws \Winter\Storm\Halcyon\Exception\MissingDatasourceException If a datasource with the given name does not exist.
      */
-    public function datasource(string|null $name = null): DatasourceInterface;
+    public function datasource(?string $name = null): DatasourceInterface;
 
     /**
      * Adds a datasource to the resolver.

--- a/src/Halcyon/Datasource/ResolverInterface.php
+++ b/src/Halcyon/Datasource/ResolverInterface.php
@@ -14,7 +14,7 @@ interface ResolverInterface
      *
      * @throws \Winter\Storm\Halcyon\Exception\MissingDatasourceException If a datasource with the given name does not exist.
      */
-    public function datasource(string $name = null): DatasourceInterface;
+    public function datasource(string|null $name = null): DatasourceInterface;
 
     /**
      * Adds a datasource to the resolver.

--- a/src/Html/BlockBuilder.php
+++ b/src/Html/BlockBuilder.php
@@ -103,7 +103,7 @@ class BlockBuilder
      *
      * If the block does not exist, then the `$default` content will be returned instead.
      */
-    public function placeholder(string $name, string $default = null): ?string
+    public function placeholder(string $name, string|null $default = null): ?string
     {
         $result = $this->get($name, $default);
         unset($this->blocks[$name]);

--- a/src/Html/BlockBuilder.php
+++ b/src/Html/BlockBuilder.php
@@ -103,7 +103,7 @@ class BlockBuilder
      *
      * If the block does not exist, then the `$default` content will be returned instead.
      */
-    public function placeholder(string $name, string|null $default = null): ?string
+    public function placeholder(string $name, ?string $default = null): ?string
     {
         $result = $this->get($name, $default);
         unset($this->blocks[$name]);

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -973,7 +973,7 @@ class FormBuilder
     /**
      * Returns a hidden HTML input, supplying the session key value.
      */
-    protected function requestHandler(string|null $name = null): string
+    protected function requestHandler(?string $name = null): string
     {
         if (!strlen($name)) {
             return '';

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -973,7 +973,7 @@ class FormBuilder
     /**
      * Returns a hidden HTML input, supplying the session key value.
      */
-    protected function requestHandler(string $name = null): string
+    protected function requestHandler(string|null $name = null): string
     {
         if (!strlen($name)) {
             return '';

--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -27,7 +27,7 @@ class HtmlBuilder
      * @param  \Illuminate\Routing\UrlGenerator  $url
      * @return void
      */
-    public function __construct(UrlGenerator $url = null)
+    public function __construct(UrlGenerator|null $url = null)
     {
         $this->url = $url;
     }

--- a/src/Html/HtmlBuilder.php
+++ b/src/Html/HtmlBuilder.php
@@ -27,7 +27,7 @@ class HtmlBuilder
      * @param  \Illuminate\Routing\UrlGenerator  $url
      * @return void
      */
-    public function __construct(UrlGenerator|null $url = null)
+    public function __construct(?UrlGenerator $url = null)
     {
         $this->url = $url;
     }

--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -370,7 +370,7 @@ class Mailer extends MailerBase
      * @param  \Closure|string  $callback
      * @return mixed
      */
-    public function laterOn($queue, $delay, $view, array $data = null, $callback = null)
+    public function laterOn($queue, $delay, $view, array|null $data = null, $callback = null)
     {
         return $this->later($delay, $view, $data, $callback, $queue);
     }

--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -370,7 +370,7 @@ class Mailer extends MailerBase
      * @param  \Closure|string  $callback
      * @return mixed
      */
-    public function laterOn($queue, $delay, $view, array|null $data = null, $callback = null)
+    public function laterOn($queue, $delay, $view, ?array $data = null, $callback = null)
     {
         return $this->later($delay, $view, $data, $callback, $queue);
     }

--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -463,7 +463,7 @@ class Http
     /**
      * Add a data to the request.
      */
-    public function data(array|string $key, array|string $value = null): self
+    public function data(array|string $key, array|string|null $value = null): self
     {
         if (is_array($key)) {
             foreach ($key as $_key => $_value) {

--- a/src/Support/helpers-array.php
+++ b/src/Support/helpers-array.php
@@ -126,7 +126,7 @@ if (!function_exists('array_first')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function array_first($array, callable|null $callback = null, $default = null)
+    function array_first($array, ?callable $callback = null, $default = null)
     {
         return Arr::first($array, $callback, $default);
     }

--- a/src/Support/helpers-array.php
+++ b/src/Support/helpers-array.php
@@ -141,7 +141,7 @@ if (!function_exists('array_last')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function array_last($array, callable|null $callback = null, $default = null)
+    function array_last($array, ?callable $callback = null, $default = null)
     {
         return Arr::last($array, $callback, $default);
     }

--- a/src/Support/helpers-array.php
+++ b/src/Support/helpers-array.php
@@ -126,7 +126,7 @@ if (!function_exists('array_first')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function array_first($array, callable $callback = null, $default = null)
+    function array_first($array, callable|null $callback = null, $default = null)
     {
         return Arr::first($array, $callback, $default);
     }
@@ -141,7 +141,7 @@ if (!function_exists('array_last')) {
      * @param  mixed  $default
      * @return mixed
      */
-    function array_last($array, callable $callback = null, $default = null)
+    function array_last($array, callable|null $callback = null, $default = null)
     {
         return Arr::last($array, $callback, $default);
     }


### PR DESCRIPTION
PHP 8.4 deprecates implicitly nullable types and applications are recommended to explicitly declare the type as nullable.
Message `Implicitly marking parameter $default as nullable is deprecated, the explicit nullable type must be used instead` is shown when declaring a default null value without declaring null in the type declaration.

To fix this, we use Union Type to declare the type also as nullable:
`string $value = null` becomes `string|null $value = null`

`composer run-script test` has been run to locate the code inside `src/` that needed to be fixed.