### PR TITLE
Override `resolveApplicationResolvingCallback()` instead of `resolveApplication()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "meyfa/phpunit-assert-gd": "^3.0.0",
         "dms/phpunit-arraysubset-asserts": "^0.5.0",
         "larastan/larastan": "^2.8.1",
-        "orchestra/testbench": "^7.1.0"
+        "orchestra/testbench": "^7.47.0"
     },
     "suggest": {
         "ext-pdo_dblib": "Required to use MS SQL Server databases",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,7 @@ class TestCase extends TestbenchTestCase
     /**
      * Resolve application implementation.
      *
-     * @return \Illuminate\Foundation\Application
+     * @return \Winter\Storm\Foundation\Application
      */
     protected function resolveApplication()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,20 +11,19 @@ use Winter\Storm\Foundation\Application;
 class TestCase extends TestbenchTestCase
 {
     /**
-     * Resolve application implementation.
+     * Resolve application resolving callback.
      *
-     * @return \Winter\Storm\Foundation\Application
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return void
      */
-    protected function resolveApplication()
+    protected function resolveApplicationResolvingCallback($app): void
     {
-        return tap(new Application($this->getBasePath()), function ($app) {
-            $app->bind(
-                \Winter\Storm\Foundation\Bootstrap\LoadConfiguration::class,
-                \Orchestra\Testbench\Bootstrap\LoadConfiguration::class
-            );
+        $app->bind(
+            \Winter\Storm\Foundation\Bootstrap\LoadConfiguration::class,
+            \Orchestra\Testbench\Bootstrap\LoadConfiguration::class
+        );
 
-            PackageManifest::swap($app, $this);
-        });
+        PackageManifest::swap($app, $this);
     }
 
     protected static function callProtectedMethod($object, $name, $params = [])

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,16 @@ use Winter\Storm\Foundation\Application;
 class TestCase extends TestbenchTestCase
 {
     /**
+     * Resolve application implementation.
+     *
+     * @return \Illuminate\Foundation\Application
+     */
+    protected function resolveApplication()
+    {
+        return new Application(static::applicationBasePath());
+    }
+    
+    /**
      * Resolve application resolving callback.
      *
      * @param  \Illuminate\Foundation\Application  $app


### PR DESCRIPTION


Improves future compatibility especially with Laravel 11 new application bootstrap.

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->