### PR TITLE
Add support for saving pivot data directly via widgets

### DIFF
--- a/src/Database/Relations/BelongsToMany.php
+++ b/src/Database/Relations/BelongsToMany.php
@@ -65,14 +65,26 @@ class BelongsToMany extends BelongsToManyBase implements RelationInterface
             return;
         }
 
-        // Convert models to keys
+        // Convert models to keys and check if pivot data exists
         if ($value instanceof Model) {
-            $value = $value->getKey();
+            if ($value->pivot instanceof Pivot) {
+                $value = [$value->getKey() => $value->pivot->toArray()];
+            } else {
+                $value = $value->getKey();
+            }
         } elseif (is_array($value)) {
+            $newValue = [];
             foreach ($value as $_key => $_value) {
                 if ($_value instanceof Model) {
-                    $value[$_key] = $_value->getKey();
+                    if ($_value->pivot instanceof Pivot) {
+                        $newValue[$_value->getKey()] = $_value->pivot->toArray();
+                    } else {
+                        $newValue[$_key] = $_value->getKey();
+                    }
                 }
+            }
+            if (count($newValue) > 0) {
+                $value = $newValue;
             }
         }
 
@@ -81,10 +93,30 @@ class BelongsToMany extends BelongsToManyBase implements RelationInterface
             $value = [$value];
         }
 
+        //Check if value has nested arrays (pivot data)
+        $keys = $value;
+        $hasPivot = false;
+        foreach ($value as $_key => $_value) {
+            if (is_array($_value)) {
+                $keys[$_key] = $_key;
+                $hasPivot = true;
+            }
+        }
+
         // Setting the relationship
         $relationCollection = $value instanceof Collection
             ? $value
-            : $relationModel->whereIn($relationModel->getKeyName(), $value)->get();
+            : $relationModel->whereIn($relationModel->getKeyName(), $keys)->get();
+
+
+        // Associate in memory immediately with pivot data (pivot of relation needs to use Winter\Storm\Database\Pivot)
+        if ($hasPivot) {
+            foreach ($relationCollection as  $_relationModel) {
+                if (isset($value[$_relationModel->id])) {
+                    $_relationModel->setRelation('pivot', $this->newPivot($value[$_relationModel->id]));
+                }
+            }
+        }
 
         // Associate in memory immediately
         $this->parent->setRelation($this->relationName, $relationCollection);

--- a/src/Database/Relations/BelongsToMany.php
+++ b/src/Database/Relations/BelongsToMany.php
@@ -65,10 +65,10 @@ class BelongsToMany extends BelongsToManyBase implements RelationInterface
             return;
         }
 
-        // Convert models to keys and check if pivot data exists
+        // if pivot data doesn't exists, Convert models to keys , else convert models to nested arrays with the keys as the indexes (pivot of relation needs to use Winter\Storm\Database\Pivot)
         if ($value instanceof Model) {
-            if ($value->pivot instanceof Pivot) {
-                $value = [$value->getKey() => $value->pivot->toArray()];
+            if ($value->{$this->getPivotAccessor()} instanceof Pivot) {
+                $value = [$value->getKey() => $value->{$this->getPivotAccessor()}->toArray()];
             } else {
                 $value = $value->getKey();
             }
@@ -76,10 +76,10 @@ class BelongsToMany extends BelongsToManyBase implements RelationInterface
             $newValue = [];
             foreach ($value as $_key => $_value) {
                 if ($_value instanceof Model) {
-                    if ($_value->pivot instanceof Pivot) {
-                        $newValue[$_value->getKey()] = $_value->pivot->toArray();
+                    if ($_value->{$this->getPivotAccessor()} instanceof Pivot) {
+                        $newValue[$_value->getKey()] = $_value->{$this->getPivotAccessor()}->toArray();
                     } else {
-                        $newValue[$_key] = $_value->getKey();
+                        $newValue[] = $_value->getKey();
                     }
                 }
             }
@@ -93,14 +93,18 @@ class BelongsToMany extends BelongsToManyBase implements RelationInterface
             $value = [$value];
         }
 
-        //Check if value has nested arrays (pivot data)
-        $keys = $value;
-        $hasPivot = false;
+        //checks if $value has nested arrays(pivot data) and regenerates the keys in a basic array format
+        $keys = [];
         foreach ($value as $_key => $_value) {
             if (is_array($_value)) {
-                $keys[$_key] = $_key;
-                $hasPivot = true;
+                $keys[] = $_key;
             }
+        }
+        if (count($keys) < 1) {
+            $keys = $value;
+            $hasPivot = false;
+        } else {
+            $hasPivot = true;
         }
 
         // Setting the relationship
@@ -109,11 +113,11 @@ class BelongsToMany extends BelongsToManyBase implements RelationInterface
             : $relationModel->whereIn($relationModel->getKeyName(), $keys)->get();
 
 
-        // Associate in memory immediately with pivot data (pivot of relation needs to use Winter\Storm\Database\Pivot)
+        // If avaliable, associate the pivot relation(s) in memory immediately (pivot of relation needs to use Winter\Storm\Database\Pivot)
         if ($hasPivot) {
             foreach ($relationCollection as  $_relationModel) {
-                if (isset($value[$_relationModel->id])) {
-                    $_relationModel->setRelation('pivot', $this->newPivot($value[$_relationModel->id]));
+                if (isset($value[$_relationModel->getKey()])) {
+                    $_relationModel->setRelation($this->getPivotAccessor(), $this->newPivot($value[$_relationModel->getKey()]));
                 }
             }
         }


### PR DESCRIPTION
I use WinterCMS for various projects. In one of them, I needed to save information  to a model with a belongsToMany relationship, including pivot data.

The Behavior RelationController provided by WinterCMS was not suitable for the specific requirements of this project. 
Upon reviewing the default Relation Widget, I decided to replicate its behavior in a custom widget.

Using getSaveValue(), my widget returns a nested array, where the field name corresponds to the name of the belongsToMany relation. When no extra data is defined in the pivot table, it correctly saves the related IDs to the database.

However, once I added an extra column (columnA) to the pivot table, the system began throwing an error: "Field 'columnA' doesn't have a default value". Setting that column to allow null removed the error, but only the related IDs were stored, columnA was always saved as null.

After several trials and adjustments to the input name structure, I encountered a different error: "Invalid column name 'pivot'". At the time, the input name format I used was:
```
input name="[Model][Relation][relation_id][pivot][columnA]" value="A"
```
Changing it to:
```
input name="[Model][Relation][relation_id][columnA]" value="A"
```
Allowed the value of columnA to be saved successfully to the pivot table. This led me to believe that I could add multiple pivot columns using a similar approach.

Unfortunately, I was wrong. When I tried adding three columns like so:
```
input name="[Model][Relation][relation_id][columnA]" value="A"
input name="[Model][Relation][relation_id][columnB]" value="B"
input name="[Model][Relation][relation_id][columnC]" value="C"
```
WinterCMS threw the following error: "Nested Arrays may not be passed to whereIn method".

Eventually, I found the root cause in the file:
```
/vendor/winter/storm/src/Database/Relations/BelongsToMany.php
```
Specifically, the issue was in the setSimpleValue() function. This function uses whereIn() (which doesn't accept nested arrays) to set the relationship, and uses sync() (which support nested arrays for storing  pivot data ) to save the data.

I made adjustments to this function, enabling widgets to save extra pivot data in belongsToMany relationships. I've successfully tested these changes over the course of a week, and I believe they can be useful to other WinterCMS developers facing similar issues.

For the project where I needed this functionality, I ultimately decided to handle pivot data manually (without a widget) for the time being.
