### PR TITLE
Update ->original  to ->originalIsEquivalent

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -352,7 +352,7 @@ class Model extends EloquentModel implements ModelInterface
          * Example usage:
          *
          *     $model->bindEvent('model.afterUpdate', function () use (\Winter\Storm\Database\Model $model) {
-         *         if ($model->title !== $model->original['title']) {
+         *         if (!$model->originalIsEquivalent('title') {
          *             \Log::info("{$model->name} updated its title!");
          *         }
          *     });
@@ -394,7 +394,7 @@ class Model extends EloquentModel implements ModelInterface
          * Example usage:
          *
          *     $model->bindEvent('model.afterSave', function () use (\Winter\Storm\Database\Model $model) {
-         *         if ($model->title !== $model->original['title']) {
+         *         if (!$model->originalIsEquivalent('title') {
          *             \Log::info("{$model->name} updated its title!");
          *         }
          *     });


### PR DESCRIPTION
Other correct notation is $model->getOriginal('title') but $model->originalIsEquivalent('title) does the compare check by default.
->original accesses a protected property which, as I've been told, is bad practice

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->