### PR TITLE
Add support for winter exceptions to provide their own response codes

### DIFF
--- a/src/Foundation/Exception/Handler.php
+++ b/src/Foundation/Exception/Handler.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Winter\Storm\Exception\AjaxException;
+use Winter\Storm\Exception\ApplicationException;
+use Winter\Storm\Exception\SystemException;
 
 class Handler extends ExceptionHandler
 {
@@ -118,17 +120,13 @@ class Handler extends ExceptionHandler
     {
         if ($throwable instanceof HttpExceptionInterface) {
             $code = $throwable->getStatusCode();
-        }
-        elseif ($throwable instanceof AjaxException) {
+        } elseif ($throwable instanceof AjaxException) {
             $code = 406;
-        }
-        elseif ($throwable instanceof SystemException && $throwable->getCode() !== 0) {
+        } elseif ($throwable instanceof SystemException && $throwable->getCode() !== 0) {
             $code = $throwable->getCode();
-        }
-        elseif ($throwable instanceof ApplicationException && $throwable->getCode() !== 0) {
+        } elseif ($throwable instanceof ApplicationException && $throwable->getCode() !== 0) {
             $code = $throwable->getCode();
-        }
-        else {
+        } else {
             $code = 500;
         }
 

--- a/src/Foundation/Exception/Handler.php
+++ b/src/Foundation/Exception/Handler.php
@@ -122,6 +122,12 @@ class Handler extends ExceptionHandler
         elseif ($throwable instanceof AjaxException) {
             $code = 406;
         }
+        elseif ($throwable instanceof SystemException && $throwable->getCode() !== 0) {
+            $code = $throwable->getCode();
+        }
+        elseif ($throwable instanceof ApplicationException && $throwable->getCode() !== 0) {
+            $code = $throwable->getCode();
+        }
         else {
             $code = 500;
         }


### PR DESCRIPTION
This PR allows for SystemException & ApplicationException to provide their own HTTP response codes, this will assist users in determining what went wrong, i.e. 400 you send something bad, 500 we did something bad.