### PR TITLE
Using hasXThrough in conjunction with soft delete

### DIFF
--- a/src/Database/Relations/HasManyThrough.php
+++ b/src/Database/Relations/HasManyThrough.php
@@ -33,7 +33,7 @@ class HasManyThrough extends HasManyThroughBase
      *
      * @return bool
      */
-    public function parentSoftDeletes()
+    public function throughParentSoftDeletes()
     {
         $uses = class_uses_recursive(get_class($this->parent));
 

--- a/src/Database/Relations/HasOneThrough.php
+++ b/src/Database/Relations/HasOneThrough.php
@@ -32,7 +32,7 @@ class HasOneThrough extends HasOneThroughBase
      *
      * @return bool
      */
-    public function parentSoftDeletes()
+    public function throughParentSoftDeletes()
     {
         $uses = class_uses_recursive(get_class($this->parent));
 

--- a/tests/Database/ModelTest.php
+++ b/tests/Database/ModelTest.php
@@ -637,6 +637,53 @@ class ModelTest extends DbTestCase
         $this->assertEquals('2', $modelMiddleRow->value);
     }
 
+    public function testHasManyThroughSoftDelete()
+    {
+        $this->getBuilder()->create('test_model1', function ($table) {
+            $table->increments('id');
+            $table->timestamps();
+        });
+
+        $this->getBuilder()->create('test_model_middle_soft_delete', function ($table) {
+            $table->increments('id');
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->integer('model1_id')->unsigned();
+            $table->foreign('model1_id')->references('id')->on('test_model1');
+        });
+
+        $this->getBuilder()->create('test_model2', function ($table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->timestamps();
+
+            $table->integer('model_middle_id')->unsigned();
+            $table->foreign('model_middle_id')->references('id')->on('test_model_middle_soft_delete');
+        });
+
+        $model1Row = TestModel1::create();
+
+        $modelMiddleRow = TestModelMiddleSoftDelete::create([
+            'model1_id' => $model1Row->id,
+        ]);
+
+        TestModel2::create([
+            'model_middle_id' => $modelMiddleRow->id,
+            'name' => 'Test',
+        ]);
+
+        $rowResult = TestModel1::with(['test_model2'])->first();
+        $this->assertEquals(1, $rowResult->test_model2->count());
+
+        $modelMiddleRow->delete();
+        Db::flushDuplicateCache();
+
+        $rowResult = TestModel1::with(['test_model2'])->first();
+        
+        $this->assertEquals(0, $rowResult->test_model2->count());
+    }
+
     public function testNicerEventOnlyBoundOnce()
     {
         $model = new TestModelVisibleWithEvent();
@@ -715,6 +762,23 @@ class TestModelHidden extends Model
     public $table = 'test_model';
 }
 
+class TestModel1 extends Model
+{
+    protected $guarded = [];
+
+    public $table = 'test_model1';
+
+    public $hasManyThrough = [
+        'test_model2' => [
+            TestModel2::class,
+            'key'        => 'model1_id',
+            'through'    => TestModelMiddleSoftDelete::class,
+            'throughKey' => 'model_middle_id',
+            'otherKey'   => 'id',
+        ],
+    ];
+}
+
 class TestModel2 extends Model
 {
     protected $guarded = [];
@@ -727,6 +791,15 @@ class TestModelMiddle extends Model
     protected $guarded = [];
 
     public $table = 'test_model_middle';
+}
+
+class TestModelMiddleSoftDelete extends Model
+{
+    use \Winter\Storm\Database\Traits\SoftDelete;
+
+    protected $guarded = [];
+
+    public $table = 'test_model_middle_soft_delete';
 }
 
 class BaseModel extends Model

--- a/tests/Database/ModelTest.php
+++ b/tests/Database/ModelTest.php
@@ -637,7 +637,7 @@ class ModelTest extends DbTestCase
         $this->assertEquals('2', $modelMiddleRow->value);
     }
 
-    public function testHasManyThroughSoftDelete()
+    public function testHasXThroughSoftDelete()
     {
         $this->getBuilder()->create('test_model1', function ($table) {
             $table->increments('id');
@@ -673,15 +673,18 @@ class ModelTest extends DbTestCase
             'name' => 'Test',
         ]);
 
-        $rowResult = TestModel1::with(['test_model2'])->first();
+        $rowResult = TestModel1::with(['test_model2', 'test_model2_one'])->first();
+
         $this->assertEquals(1, $rowResult->test_model2->count());
+        $this->assertNotEquals(null, $rowResult->test_model2_one);
 
         $modelMiddleRow->delete();
-        Db::flushDuplicateCache();
 
-        $rowResult = TestModel1::with(['test_model2'])->first();
-        
+        Db::flushDuplicateCache();
+        $rowResult = TestModel1::with(['test_model2', 'test_model2_one'])->first();
+
         $this->assertEquals(0, $rowResult->test_model2->count());
+        $this->assertEquals(null, $rowResult->test_model2_one);
     }
 
     public function testNicerEventOnlyBoundOnce()
@@ -770,6 +773,15 @@ class TestModel1 extends Model
 
     public $hasManyThrough = [
         'test_model2' => [
+            TestModel2::class,
+            'key'        => 'model1_id',
+            'through'    => TestModelMiddleSoftDelete::class,
+            'throughKey' => 'model_middle_id',
+            'otherKey'   => 'id',
+        ],
+    ];
+    public $hasOneThrough = [
+        'test_model2_one' => [
             TestModel2::class,
             'key'        => 'model1_id',
             'through'    => TestModelMiddleSoftDelete::class,


### PR DESCRIPTION
Currently, hasManyThrough allows access to a record from a source table to a target table: table1 -> hasmany -> table_middle -> hasmany -> table2.

It now correctly detects when there are items deleted by soft delete in table_middle.

Due to the wintercms query cache, I had to use "Db::flushDuplicateCache()" during testing to retrieve table1 with the results from table2. I don't know how to avoid this problem.

- Using hasManyThrough in conjunction with soft delete on the intermediate table now respects trashed items
- Testing for hasManyThrough in conjunction with soft delete on the intermediate table