### PR TITLE
Check if concats exists as a property on the querybuilder

### DIFF
--- a/src/Database/Query/Grammars/Concerns/SelectConcatenations.php
+++ b/src/Database/Query/Grammars/Concerns/SelectConcatenations.php
@@ -19,7 +19,7 @@ trait SelectConcatenations
     {
         $select = parent::compileColumns($query, $columns);
 
-        if (count($query->concats)) {
+        if (property_exists($query, 'concats') && is_array($query->concats) && count($query->concats)) {
             $select .= $this->compileConcats($query);
         }
 


### PR DESCRIPTION
This is a workaround but not a solution. Please accept the solution until you find a solution.