### PR TITLE
Use pivot model table name if not defined in the relation

### DIFF
--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -440,7 +440,7 @@ trait HasRelationships
             case 'belongsToMany':
                 $relation = $this->belongsToMany(
                     $relatedClass,
-                    $definition['pivotModel'] ?? $definition['table'] ?? null,
+                    $definition['table'] ?? $definition['pivotModel'] ?? null,
                     $definition['key'] ?? null,
                     $definition['otherKey'] ?? null,
                     $definition['parentKey'] ?? null,

--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -481,7 +481,7 @@ trait HasRelationships
                 $relation = $this->morphToMany(
                     $relatedClass,
                     $definition['name'] ?? $relationName,
-                    $definition['pivotModel'] ?? $definition['table'] ?? null,
+                    $definition['table'] ?? $definition['pivotModel'] ?? null,
                     $definition['key'] ?? null,
                     $definition['otherKey'] ?? null,
                     $definition['parentKey'] ?? null,

--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -440,7 +440,7 @@ trait HasRelationships
             case 'belongsToMany':
                 $relation = $this->belongsToMany(
                     $relatedClass,
-                    $definition['table'] ?? null,
+                    $definition['table'] ?? $definition['pivotModel'] ?? null,
                     $definition['key'] ?? null,
                     $definition['otherKey'] ?? null,
                     $definition['parentKey'] ?? null,

--- a/src/Database/Concerns/HasRelationships.php
+++ b/src/Database/Concerns/HasRelationships.php
@@ -440,7 +440,7 @@ trait HasRelationships
             case 'belongsToMany':
                 $relation = $this->belongsToMany(
                     $relatedClass,
-                    $definition['table'] ?? $definition['pivotModel'] ?? null,
+                    $definition['pivotModel'] ?? $definition['table'] ?? null,
                     $definition['key'] ?? null,
                     $definition['otherKey'] ?? null,
                     $definition['parentKey'] ?? null,
@@ -481,7 +481,7 @@ trait HasRelationships
                 $relation = $this->morphToMany(
                     $relatedClass,
                     $definition['name'] ?? $relationName,
-                    $definition['table'] ?? null,
+                    $definition['pivotModel'] ?? $definition['table'] ?? null,
                     $definition['key'] ?? null,
                     $definition['otherKey'] ?? null,
                     $definition['parentKey'] ?? null,

--- a/tests/Database/Relations/BelongsToManyTest.php
+++ b/tests/Database/Relations/BelongsToManyTest.php
@@ -3,6 +3,7 @@
 namespace Winter\Storm\Tests\Database\Relations;
 
 use Winter\Storm\Database\Model;
+use Winter\Storm\Database\Pivot;
 use Winter\Storm\Support\Facades\DB;
 use Winter\Storm\Tests\Database\Fixtures\Category;
 use Winter\Storm\Tests\Database\Fixtures\Post;
@@ -369,4 +370,27 @@ class BelongsToManyTest extends DbTestCase
         $this->assertEquals([1, 2], $author->executiveAuthors()->lists('id'));
         $this->assertEquals([1, 2], $author->executiveAuthors()->get()->lists('id'));
     }
+
+    function testTableDefaultsToCustomPivotTable()
+    {
+        $model = new TestModel();
+        $relation = $model->{'dependencies'}();
+
+        $this->assertEquals('custom_pivot_table', $relation->getTable());
+    }
+}
+
+class TestModel extends Model
+{
+    public $belongsToMany = [
+        'dependencies' => [
+            Model::class,
+            'pivotModel' => TestCustomPivotModel::class,
+        ],
+    ];
+}
+
+class TestCustomPivotModel extends Pivot
+{
+    public $table = 'custom_pivot_table';
 }

--- a/tests/Database/Relations/BelongsToManyTest.php
+++ b/tests/Database/Relations/BelongsToManyTest.php
@@ -396,6 +396,20 @@ class BelongsToManyTest extends DbTestCase
 
         $this->assertEquals('custom_pivot_without_table', $relation->getTable());
     }
+
+    public function testTableDefaultsToRelationTable()
+    {
+        $model = new TestModel();
+        $model->addBelongsToManyRelation('pivot_without_table', [
+            Model::class,
+            'table' => 'custom_pivot_table',
+            'pivotModel' => CustomPivotWithoutTable::class,
+        ]);
+
+        $relation = $model->pivot_without_table();
+
+        $this->assertEquals('custom_pivot_table', $relation->getTable());
+    }
 }
 
 class TestModel extends Model

--- a/tests/Database/Relations/BelongsToManyTest.php
+++ b/tests/Database/Relations/BelongsToManyTest.php
@@ -379,7 +379,7 @@ class BelongsToManyTest extends DbTestCase
             'pivotModel' => CustomPivotWithTable::class,
         ]);
 
-        $relation = $model->{'pivot_with_table'}();
+        $relation = $model->pivot_with_table();
 
         $this->assertEquals('custom_pivot_table', $relation->getTable());
     }
@@ -392,20 +392,14 @@ class BelongsToManyTest extends DbTestCase
             'pivotModel' => CustomPivotWithoutTable::class,
         ]);
 
-        $relation = $model->{'pivot_without_table'}();
+        $relation = $model->pivot_without_table();
 
-        $this->assertEquals('custom_pivot_table', $relation->getTable());
+        $this->assertEquals('custom_pivot_without_table', $relation->getTable());
     }
 }
 
 class TestModel extends Model
 {
-    public $belongsToMany = [
-        'dependencies' => [
-            Model::class,
-            'pivotModel' => TestCustomPivotModel::class,
-        ],
-    ];
 }
 
 class CustomPivotWithTable extends Pivot

--- a/tests/Database/Relations/BelongsToManyTest.php
+++ b/tests/Database/Relations/BelongsToManyTest.php
@@ -374,7 +374,25 @@ class BelongsToManyTest extends DbTestCase
     public function testTableDefaultsToCustomPivotTable()
     {
         $model = new TestModel();
-        $relation = $model->{'dependencies'}();
+        $model->addBelongsToManyRelation('pivot_with_table', [
+            Model::class,
+            'pivotModel' => CustomPivotWithTable::class,
+        ]);
+
+        $relation = $model->{'pivot_with_table'}();
+
+        $this->assertEquals('custom_pivot_table', $relation->getTable());
+    }
+
+    public function testTableDefaultsToCustomPivotTableWithoutTable()
+    {
+        $model = new TestModel();
+        $model->addBelongsToManyRelation('pivot_without_table', [
+            Model::class,
+            'pivotModel' => CustomPivotWithoutTable::class,
+        ]);
+
+        $relation = $model->{'pivot_without_table'}();
 
         $this->assertEquals('custom_pivot_table', $relation->getTable());
     }
@@ -390,7 +408,11 @@ class TestModel extends Model
     ];
 }
 
-class TestCustomPivotModel extends Pivot
+class CustomPivotWithTable extends Pivot
 {
     public $table = 'custom_pivot_table';
+}
+
+class CustomPivotWithoutTable extends Pivot
+{
 }

--- a/tests/Database/Relations/BelongsToManyTest.php
+++ b/tests/Database/Relations/BelongsToManyTest.php
@@ -371,7 +371,7 @@ class BelongsToManyTest extends DbTestCase
         $this->assertEquals([1, 2], $author->executiveAuthors()->get()->lists('id'));
     }
 
-    function testTableDefaultsToCustomPivotTable()
+    public function testTableDefaultsToCustomPivotTable()
     {
         $model = new TestModel();
         $relation = $model->{'dependencies'}();


### PR DESCRIPTION
If using a custom pivot model, the table name may be omitted in the relation definition if it is set in the custom pivot model itself.

Laravel will resolve the table name to the Pivot model table.
(ref. https://github.com/laravel/framework/blob/12.x/src/Illuminate/Database/Eloquent/Relations/BelongsToMany.php#L184-L201)