### PR TITLE
LessCompiler: Explicitly set strictMath:false for Less.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/console": "^6.4",
         "symfony/yaml": "^6.0",
         "twig/twig": "^3.14",
-        "wikimedia/less.php": "~3.0",
+        "wikimedia/less.php": "^5.0",
         "wikimedia/minify": "~2.2",
         "winter/laravel-config-writer": "^1.0.1"
     },

--- a/src/Parse/Assetic/Filter/LessCompiler.php
+++ b/src/Parse/Assetic/Filter/LessCompiler.php
@@ -30,6 +30,7 @@ class LessCompiler extends BaseFilter implements HashableInterface, DependencyEx
     public function filterLoad(AssetInterface $asset)
     {
         $parser = new Less_Parser();
+        
         // Ensure unchanged behavior across Less.php 3.x and Less.php 5.x
         $parser->SetOption('strictMath', false);
 

--- a/src/Parse/Assetic/Filter/LessCompiler.php
+++ b/src/Parse/Assetic/Filter/LessCompiler.php
@@ -30,6 +30,8 @@ class LessCompiler extends BaseFilter implements HashableInterface, DependencyEx
     public function filterLoad(AssetInterface $asset)
     {
         $parser = new Less_Parser();
+        // Ensure unchanged behavior across Less.php 3.x and Less.php 5.x
+        $parser->SetOption('strictMath', false);
 
         // CSS Rewriter will take care of this
         $parser->SetOption('relativeUrls', false);


### PR DESCRIPTION
In Less.js 1.x-3.x the default was strictMath:false, which means math is eagerly evaluated, instead of only "strictly" between parenthesis.

This has the downside of interpreting "/" slashes in newer CSS syntax as Less division, instead of as separator between values in those CSS features (aspect-ratio, border-radius, font).

As such, Less.js 4.x, and Less.php 5.x, renamed "strictMath" to "math", with a new third option "parens-division" as the  default, alongside "always" (aka strictMath:false) and "parens" (aka strictMath:true). This option means math is still eagerly evaluated in most cases (plus, minus, multiply, etc) but no longer for division. I don't know if or when the Winter ecosystem wants to adopt this new default, but for now, to minimise disruption and unblock the Less.php upgrade, I suggest simply setting `strictMath: false` explicitly so that when someone installs Less.php 5.x, they get the same behavior as before.

This decouples the trivial Less.php upgrade from the (potentially non-trivial, or unwanted) math migration.

Ref https://phabricator.wikimedia.org/T366445.
Ref https://github.com/wikimedia/less.php/blob/master/CHANGES.md.

**See also**:
* https://github.com/assetic-php/assetic/pull/38