### PR TITLE
Remove emptyOption after using it to fill the options array

### DIFF
--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -412,6 +412,7 @@ class FormBuilder
     {
         if (array_key_exists('emptyOption', $options)) {
             $list = ['' => $options['emptyOption']] + $list;
+            unset($options['emptyOption']);
         }
 
         // When building a select box the "value" attribute is really the selected one

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -319,4 +319,25 @@ class FormBuilderTest extends TestCase
         $this->assertElementAttributeEquals('type', 'submit', $result);
         $this->assertElementContainsText('Apply', $result);
     }
+
+    /**
+     * @testdox can create a select element with an empty option without emptyOption appearing as an attribute.
+     */
+    public function testSelectWithEmptyOption()
+    {
+        $result = $this->formBuilder->select(
+            name: 'my-select',
+            list: ['1' => 'Option 1', '2' => 'Option 2'],
+            selected: null,
+            options: ['emptyOption' => 'Please select', 'class' => 'form-control']
+        );
+
+        $this->assertElementIs('select', $result);
+        $this->assertElementAttributeEquals('name', 'my-select', $result);
+        $this->assertElementAttributeEquals('class', 'form-control', $result);
+        $this->assertElementDoesntHaveAttribute('emptyOption', $result);
+        $this->assertStringContainsString('<option value="">Please select</option>', $result);
+        $this->assertStringContainsString('<option value="1">Option 1</option>', $result);
+        $this->assertStringContainsString('<option value="2">Option 2</option>', $result);
+    }
 }


### PR DESCRIPTION
This prevent the <select> node to end-up with an unnecessary "emptyOption" attribute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where empty option values were incorrectly appearing as attributes in select form elements; dropdowns now render correctly when an empty/placeholder option is configured.
* **Tests**
  * Added a test verifying select rendering with an empty/placeholder option and ensuring no stray attributes are produced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->