### PR TITLE
Add image/icon support for FormBuilder::select

### DIFF
--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -416,12 +416,6 @@ class FormBuilder
      *
      * Icons are detected when the second array element doesn't contain a dot (.).
      * Images are detected when the second array element contains a dot (.).
-     *
-     * @param string $name The name attribute for the select element
-     * @param array $list The options list (see above for supported formats)
-     * @param string|array|null $selected The selected value(s)
-     * @param array $options Additional HTML attributes for the select element
-     * @return string The generated HTML select element
      */
     public function select(string $name, array $list = [], string|array|null $selected = null, array $options = []): string
     {
@@ -502,11 +496,6 @@ class FormBuilder
      * - If $display is an array with string keys, creates an optgroup
      * - If $display is an array with numeric keys (e.g., ['Label', 'icon']), creates a single option with icon/image
      * - If $display is a string, creates a simple option
-     *
-     * @param string|array $display The display value or array for optgroup/icon/image
-     * @param string $value The option value attribute
-     * @param string|array|null $selected The selected value(s)
-     * @return string The generated HTML option or optgroup element
      */
     public function getSelectOption(string|array $display, string $value, string|array|null $selected = null): string
     {
@@ -540,11 +529,6 @@ class FormBuilder
      * If $display is an array in the format ['Label', 'icon-or-image'], adds data attributes:
      * - data-icon: added if the second element doesn't contain a dot (e.g., 'icon-refresh')
      * - data-image: added if the second element contains a dot (e.g., 'image.png')
-     *
-     * @param string|array $display The display label or array with label and icon/image
-     * @param string $value The option value attribute
-     * @param string|array|null $selected The selected value(s)
-     * @return string The generated HTML option element
      */
     protected function option(string|array $display, string $value, string|array|null $selected = null): string
     {

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -486,7 +486,7 @@ class FormBuilder
     {
         if (is_array($display)) {
             $keys = array_keys($display);
-            if (count($keys) && gettype($keys[0]) === 'string') {
+            if (count($keys) && is_string($keys[0])) {
                 return $this->optionGroup($display, $value, $selected);
             }
         }

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -408,7 +408,7 @@ class FormBuilder
     /**
      * Create a select box field with empty option support.
      */
-    public function select(string $name, array $list = [], string|array|null $selected = null, array $options = []): string
+    public function select(string $name, array $list = [], string|array|null $selected = null, array $options = [], bool $legacyOptGroup = true): string
     {
         if (array_key_exists('emptyOption', $options)) {
             $list = ['' => $options['emptyOption']] + $list;
@@ -431,7 +431,7 @@ class FormBuilder
         $html = [];
 
         foreach ($list as $value => $display) {
-            $html[] = $this->getSelectOption($display, $value, $selected);
+            $html[] = $this->getSelectOption($display, $value, $selected, $legacyOptGroup);
         }
 
         // Once we have all of this HTML, we can join this into a single element after
@@ -482,10 +482,14 @@ class FormBuilder
     /**
      * Get the select option for the given value.
      */
-    public function getSelectOption(string|array $display, string $value, string|array|null $selected = null): string
+    public function getSelectOption(string|array $display, string $value, string|array|null $selected = null, bool $legacyOptGroup = true): string
     {
         if (is_array($display)) {
-            return $this->optionGroup($display, $value, $selected);
+            if ($legacyOptGroup) {
+                return $this->optionGroup($display, $value, $selected);
+            } elseif ($items = array_get($display, 'items')) {
+                return $this->optionGroup($items, $value, $selected);
+            }
         }
 
         return $this->option($display, $value, $selected);
@@ -508,7 +512,7 @@ class FormBuilder
     /**
      * Create a select element option.
      */
-    protected function option(string $display, string $value, string|array|null $selected = null): string
+    protected function option(string|array $display, string $value, string|array|null $selected = null): string
     {
         $selectedAttr = $this->getSelectedValue($value, $selected);
 
@@ -517,6 +521,15 @@ class FormBuilder
             'selected' => $selectedAttr
         ];
 
+        if (is_array($display)) {
+            $data = array_get($display, 1);
+            $display = array_get($display, 0);
+            if (strpos($data, '.')) {
+                $options['data-image'] = $data;
+            } else {
+                $options['data-icon'] = $data;
+            }
+        }
         return '<option' . $this->html->attributes($options) . '>' . e($display) . '</option>';
     }
 

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -532,7 +532,7 @@ class FormBuilder
         $selectedAttr = $this->getSelectedValue($value, $selected);
 
         $options = [
-            'value' => e($value),
+            'value' => $value,
             'selected' => $selectedAttr
         ];
 

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -408,7 +408,7 @@ class FormBuilder
     /**
      * Create a select box field with empty option support.
      */
-    public function select(string $name, array $list = [], string|array|null $selected = null, array $options = [], bool $legacyOptGroup = true): string
+    public function select(string $name, array $list = [], string|array|null $selected = null, array $options = []): string
     {
         if (array_key_exists('emptyOption', $options)) {
             $list = ['' => $options['emptyOption']] + $list;
@@ -431,7 +431,7 @@ class FormBuilder
         $html = [];
 
         foreach ($list as $value => $display) {
-            $html[] = $this->getSelectOption($display, $value, $selected, $legacyOptGroup);
+            $html[] = $this->getSelectOption($display, $value, $selected);
         }
 
         // Once we have all of this HTML, we can join this into a single element after
@@ -482,13 +482,12 @@ class FormBuilder
     /**
      * Get the select option for the given value.
      */
-    public function getSelectOption(string|array $display, string $value, string|array|null $selected = null, bool $legacyOptGroup = true): string
+    public function getSelectOption(string|array $display, string $value, string|array|null $selected = null): string
     {
         if (is_array($display)) {
-            if ($legacyOptGroup) {
+            $keys = array_keys($display);
+            if (count($keys) && gettype($keys[0]) === 'string') {
                 return $this->optionGroup($display, $value, $selected);
-            } elseif ($items = array_get($display, 'items')) {
-                return $this->optionGroup($items, $value, $selected);
             }
         }
 
@@ -522,7 +521,7 @@ class FormBuilder
         ];
 
         if (is_array($display)) {
-            $data = array_get($display, 1, 'icon-snowflake');
+            $data = array_get($display, 1, '');
             $display = array_get($display, 0);
             if (strpos($data, '.')) {
                 $options['data-image'] = $data;

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -537,13 +537,17 @@ class FormBuilder
         ];
 
         if (is_array($display)) {
-            $data = array_get($display, 1, '');
-            $display = array_get($display, 0);
-            if (strpos($data, '.') !== false) {
-                $options['data-image'] = $data;
-            } else {
-                $options['data-icon'] = $data;
+            $label = array_get($display, 0);
+            $data = array_get($display, 1);
+
+            if (is_string($data) && $data !== '') {
+                if (strpos($data, '.') !== false) {
+                    $options['data-image'] = $data;
+                } else {
+                    $options['data-icon'] = $data;
+                }
             }
+            $display = $label;
         }
         return '<option' . $this->html->attributes($options) . '>' . e($display) . '</option>';
     }

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -523,7 +523,7 @@ class FormBuilder
         if (is_array($display)) {
             $data = array_get($display, 1, '');
             $display = array_get($display, 0);
-            if (strpos($data, '.')) {
+            if (strpos($data, '.') !== false) {
                 $options['data-image'] = $data;
             } else {
                 $options['data-icon'] = $data;

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -522,7 +522,7 @@ class FormBuilder
         ];
 
         if (is_array($display)) {
-            $data = array_get($display, 1);
+            $data = array_get($display, 1, 'icon-snowflake');
             $display = array_get($display, 0);
             if (strpos($data, '.')) {
                 $options['data-image'] = $data;

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -499,11 +499,8 @@ class FormBuilder
      */
     public function getSelectOption(string|array $display, string $value, string|array|null $selected = null): string
     {
-        if (is_array($display)) {
-            $keys = array_keys($display);
-            if (count($keys) && is_string($keys[0])) {
-                return $this->optionGroup($display, $value, $selected);
-            }
+        if (is_array($display) && array_keys($display) !== [0,1]) {
+            return $this->optionGroup($display, $value, $selected);
         }
 
         return $this->option($display, $value, $selected);

--- a/src/Html/FormBuilder.php
+++ b/src/Html/FormBuilder.php
@@ -407,6 +407,21 @@ class FormBuilder
 
     /**
      * Create a select box field with empty option support.
+     *
+     * Supports several formats for the $list parameter:
+     * - Simple format: ['value' => 'Label']
+     * - With icon/image: ['value' => ['Label', 'icon-name']] or ['value' => ['Label', 'image.png']]
+     * - With optgroups: ['Group Name' => ['value' => 'Label', ...]]
+     * - Mixed format combining all of the above
+     *
+     * Icons are detected when the second array element doesn't contain a dot (.).
+     * Images are detected when the second array element contains a dot (.).
+     *
+     * @param string $name The name attribute for the select element
+     * @param array $list The options list (see above for supported formats)
+     * @param string|array|null $selected The selected value(s)
+     * @param array $options Additional HTML attributes for the select element
+     * @return string The generated HTML select element
      */
     public function select(string $name, array $list = [], string|array|null $selected = null, array $options = []): string
     {
@@ -482,6 +497,16 @@ class FormBuilder
 
     /**
      * Get the select option for the given value.
+     *
+     * Determines whether to create a single option or an optgroup based on the $display parameter:
+     * - If $display is an array with string keys, creates an optgroup
+     * - If $display is an array with numeric keys (e.g., ['Label', 'icon']), creates a single option with icon/image
+     * - If $display is a string, creates a simple option
+     *
+     * @param string|array $display The display value or array for optgroup/icon/image
+     * @param string $value The option value attribute
+     * @param string|array|null $selected The selected value(s)
+     * @return string The generated HTML option or optgroup element
      */
     public function getSelectOption(string|array $display, string $value, string|array|null $selected = null): string
     {
@@ -511,6 +536,15 @@ class FormBuilder
 
     /**
      * Create a select element option.
+     *
+     * If $display is an array in the format ['Label', 'icon-or-image'], adds data attributes:
+     * - data-icon: added if the second element doesn't contain a dot (e.g., 'icon-refresh')
+     * - data-image: added if the second element contains a dot (e.g., 'image.png')
+     *
+     * @param string|array $display The display label or array with label and icon/image
+     * @param string $value The option value attribute
+     * @param string|array|null $selected The selected value(s)
+     * @return string The generated HTML option element
      */
     protected function option(string|array $display, string $value, string|array|null $selected = null): string
     {

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -340,4 +340,170 @@ class FormBuilderTest extends TestCase
         $this->assertStringContainsString('<option value="1">Option 1</option>', $result);
         $this->assertStringContainsString('<option value="2">Option 2</option>', $result);
     }
+
+    /**
+     * @testdox can create a select element with icon data attributes.
+     */
+    public function testSelectWithIcon()
+    {
+        $result = $this->formBuilder->select(
+            name: 'my-select',
+            list: [
+                '1' => 'Regular Option',
+                '2' => ['Option With Icon', 'icon-refresh'],
+            ],
+            selected: null,
+            options: []
+        );
+
+        $this->assertElementIs('select', $result);
+        $this->assertElementAttributeEquals('name', 'my-select', $result);
+        $this->assertStringContainsString('<option value="1">Regular Option</option>', $result);
+        $this->assertStringContainsString('<option value="2" data-icon="icon-refresh">Option With Icon</option>', $result);
+    }
+
+    /**
+     * @testdox can create a select element with image data attributes.
+     */
+    public function testSelectWithImage()
+    {
+        $result = $this->formBuilder->select(
+            name: 'my-select',
+            list: [
+                '1' => 'Regular Option',
+                '2' => ['Option With Image', 'myImage.jpeg'],
+            ],
+            selected: null,
+            options: []
+        );
+
+        $this->assertElementIs('select', $result);
+        $this->assertElementAttributeEquals('name', 'my-select', $result);
+        $this->assertStringContainsString('<option value="1">Regular Option</option>', $result);
+        $this->assertStringContainsString('<option value="2" data-image="myImage.jpeg">Option With Image</option>', $result);
+    }
+
+    /**
+     * @testdox can create a select element with optgroups.
+     */
+    public function testSelectWithOptgroups()
+    {
+        $result = $this->formBuilder->select(
+            name: 'my-select',
+            list: [
+                'Group 1' => [
+                    'g1-opt1' => 'Group 1 Option 1',
+                    'g1-opt2' => 'Group 1 Option 2',
+                ],
+                'Group 2' => [
+                    'g2-opt1' => 'Group 2 Option 1',
+                    'g2-opt2' => 'Group 2 Option 2',
+                ],
+            ],
+            selected: null,
+            options: []
+        );
+
+        $this->assertElementIs('select', $result);
+        $this->assertElementAttributeEquals('name', 'my-select', $result);
+        $this->assertStringContainsString('<optgroup label="Group 1">', $result);
+        $this->assertStringContainsString('<optgroup label="Group 2">', $result);
+        $this->assertStringContainsString('<option value="g1-opt1">Group 1 Option 1</option>', $result);
+        $this->assertStringContainsString('<option value="g1-opt2">Group 1 Option 2</option>', $result);
+        $this->assertStringContainsString('<option value="g2-opt1">Group 2 Option 1</option>', $result);
+        $this->assertStringContainsString('<option value="g2-opt2">Group 2 Option 2</option>', $result);
+        $this->assertStringContainsString('</optgroup>', $result);
+    }
+
+    /**
+     * @testdox can create a select element with optgroups containing icons and images.
+     */
+    public function testSelectWithOptgroupsAndIconsImages()
+    {
+        $result = $this->formBuilder->select(
+            name: 'my-select',
+            list: [
+                'option1' => 'Regular option',
+                'option2' => ['Option With Image', 'myImage.jpeg'],
+                'Group1' => [
+                    'group1-opt1' => 'OptGroup Option1 regular option',
+                    'group1-opt2' => ['OptGroup Option2 with icon', 'icon-refresh'],
+                    'group1-opt3' => ['OptGroup Option3 with image', 'otherImage.png'],
+                ],
+                'Group2' => [
+                    'group2-opt1' => 'OptGroup2 Option1',
+                    'group2-opt2' => 'OptGroup2 Option2',
+                ],
+            ],
+            selected: null,
+            options: []
+        );
+
+        $this->assertElementIs('select', $result);
+        $this->assertElementAttributeEquals('name', 'my-select', $result);
+
+        // Regular options
+        $this->assertStringContainsString('<option value="option1">Regular option</option>', $result);
+        $this->assertStringContainsString('<option value="option2" data-image="myImage.jpeg">Option With Image</option>', $result);
+
+        // Optgroups
+        $this->assertStringContainsString('<optgroup label="Group1">', $result);
+        $this->assertStringContainsString('<optgroup label="Group2">', $result);
+
+        // Options inside optgroups
+        $this->assertStringContainsString('<option value="group1-opt1">OptGroup Option1 regular option</option>', $result);
+        $this->assertStringContainsString('<option value="group1-opt2" data-icon="icon-refresh">OptGroup Option2 with icon</option>', $result);
+        $this->assertStringContainsString('<option value="group1-opt3" data-image="otherImage.png">OptGroup Option3 with image</option>', $result);
+        $this->assertStringContainsString('<option value="group2-opt1">OptGroup2 Option1</option>', $result);
+        $this->assertStringContainsString('<option value="group2-opt2">OptGroup2 Option2</option>', $result);
+    }
+
+    /**
+     * @testdox can create a select element with backward compatibility for simple string options.
+     */
+    public function testSelectBackwardCompatibility()
+    {
+        $result = $this->formBuilder->select(
+            name: 'my-select',
+            list: [
+                '1' => 'Option 1',
+                '2' => 'Option 2',
+                '3' => 'Option 3',
+            ],
+            selected: '2',
+            options: []
+        );
+
+        $this->assertElementIs('select', $result);
+        $this->assertElementAttributeEquals('name', 'my-select', $result);
+        $this->assertStringContainsString('<option value="1">Option 1</option>', $result);
+        $this->assertStringContainsString('<option value="2" selected="selected">Option 2</option>', $result);
+        $this->assertStringContainsString('<option value="3">Option 3</option>', $result);
+        $this->assertStringNotContainsString('data-icon', $result);
+        $this->assertStringNotContainsString('data-image', $result);
+    }
+
+    /**
+     * @testdox properly escapes HTML in option labels and values.
+     */
+    public function testSelectHtmlEscaping()
+    {
+        $result = $this->formBuilder->select(
+            name: 'my-select',
+            list: [
+                '<script>' => 'Normal Label',
+                'safe-value' => ['<b>Bold Label</b>', 'icon-test'],
+            ],
+            selected: null,
+            options: []
+        );
+
+        $this->assertElementIs('select', $result);
+        // The value attribute is escaped by the HtmlBuilder, resulting in double encoding
+        $this->assertStringContainsString('value="&amp;lt;script&amp;gt;"', $result);
+        $this->assertStringContainsString('&lt;b&gt;Bold Label&lt;/b&gt;', $result);
+        // Ensure dangerous tags are not rendered as raw HTML
+        $this->assertStringNotContainsString('value="<script>"', $result);
+        $this->assertStringNotContainsString('<b>Bold Label</b>', $result);
+    }
 }

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -584,7 +584,7 @@ class FormBuilderTest extends TestCase
 
         $this->assertElementIs('select', $result);
         // The value attribute is escaped by the HtmlBuilder, resulting in double encoding
-        $this->assertStringContainsString('value="&amp;lt;script&amp;gt;"', $result);
+        $this->assertStringContainsString('value="&lt;script&gt;"', $result);
         $this->assertStringContainsString('&lt;b&gt;Bold Label&lt;/b&gt;', $result);
         // Ensure dangerous tags are not rendered as raw HTML
         $this->assertStringNotContainsString('value="<script>"', $result);

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -583,9 +583,10 @@ class FormBuilderTest extends TestCase
         );
 
         $this->assertElementIs('select', $result);
-        // The value attribute is escaped by the HtmlBuilder, resulting in double encoding
+
         $this->assertStringContainsString('value="&lt;script&gt;"', $result);
         $this->assertStringContainsString('&lt;b&gt;Bold Label&lt;/b&gt;', $result);
+
         // Ensure dangerous tags are not rendered as raw HTML
         $this->assertStringNotContainsString('value="<script>"', $result);
         $this->assertStringNotContainsString('<b>Bold Label</b>', $result);

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -535,7 +535,6 @@ class FormBuilderTest extends TestCase
                     1 => 'Option 2',
                 ],
             ],
-            selected: 1,
             options: []
         );
 

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -484,6 +484,70 @@ class FormBuilderTest extends TestCase
     }
 
     /**
+     * @testdox can create a select element with backward compatibility for optgroup integer keys
+     */
+    public function testSelectBackwardCompatibilityOptgroupIdItemsKeys()
+    {
+        // this simulates grouped options base on a model with ids as keys
+        $result = $this->formBuilder->select(
+            name: 'my-select',
+            list: [
+                'Group1' => [
+                    1 => 'Option 1',
+                    2 => 'Option 2',
+                ],
+                'Group2' => [
+                    3 => 'Option 3',
+                    4 => 'Option 4',
+                ],
+            ],
+            selected: 2,
+            options: []
+        );
+
+        $this->assertElementIs('select', $result);
+        $this->assertElementAttributeEquals('name', 'my-select', $result);
+
+        // Optgroups
+        $this->assertStringContainsString('<optgroup label="Group1">', $result);
+        $this->assertStringContainsString('<optgroup label="Group2">', $result);
+
+        // Options inside optgroups
+        $this->assertStringContainsString('<option value="1">Option 1</option>', $result);
+        $this->assertStringContainsString('<option value="2" selected="selected">Option 2</option>', $result);
+        $this->assertStringContainsString('<option value="3">Option 3</option>', $result);
+        $this->assertStringContainsString('<option value="4">Option 4</option>', $result);
+        $this->assertStringNotContainsString('data-icon', $result);
+        $this->assertStringNotContainsString('data-image', $result);
+    }
+
+    /**
+     * @testdox show case where backward compatibility is broken (expected)
+     */
+    public function testSelectBackwardCompatibilityBrokenOptGroup()
+    {
+        // optgroup syntax with two items with integer keys starting at zero are seen as a regular option with an icon
+        $result = $this->formBuilder->select(
+            name: 'my-select',
+            list: [
+                'Group1' => [
+                    0 => 'Option 1',
+                    1 => 'Option 2',
+                ],
+            ],
+            selected: 1,
+            options: []
+        );
+
+        $this->assertElementIs('select', $result);
+        $this->assertElementAttributeEquals('name', 'my-select', $result);
+
+        // Options inside optgroups
+        $this->assertStringContainsString('<option value="Group1" data-icon="Option 2">Option 1</option>', $result);
+        $this->assertStringContainsString('data-icon', $result);
+    }
+
+    /**
      * @testdox properly escapes HTML in option labels and values.
      */
     public function testSelectHtmlEscaping()

--- a/tests/Html/FormBuilderTest.php
+++ b/tests/Html/FormBuilderTest.php
@@ -384,6 +384,27 @@ class FormBuilderTest extends TestCase
     }
 
     /**
+     * @testdox can create a select element with image data attributes.
+     */
+    public function testSelectWithSelectedImage()
+    {
+        $result = $this->formBuilder->select(
+            name: 'my-select',
+            list: [
+                '1' => 'Regular Option',
+                '2' => ['Option With Image', 'myImage.jpeg'],
+            ],
+            selected: '2',
+            options: []
+        );
+
+        $this->assertElementIs('select', $result);
+        $this->assertElementAttributeEquals('name', 'my-select', $result);
+        $this->assertStringContainsString('<option value="1">Regular Option</option>', $result);
+        $this->assertStringContainsString('<option value="2" selected="selected" data-image="myImage.jpeg">Option With Image</option>', $result);
+    }
+
+    /**
      * @testdox can create a select element with optgroups.
      */
     public function testSelectWithOptgroups()


### PR DESCRIPTION
Enhanced usage:
```php
$list = [
    "option1" => "regular option",
    "option2" => ["Option With Image", "myImage.jpeg"],
    "Group1"  => [
        "group1-opt1" => "OptGroup Option1 regular option",
        "group1-opt2" => ["OptGroup Option2 with icon", "icon-refresh"],
        "group1-opt3" => ["OptGroup Option3 with image", "otherImage.png"],
     ],
    "Group2"  => [
        "group2-opt1" => "OptGroup2 Option1",
        "group2-opt2" => "OptGroup2 Option2",
        "group2-opt3" => "OptGroup2 Option3",
     ],
];
Form::select($name, $list, $selected, $options);
```
Backward compatibility is maintained, and once I update the `_field_dropdown` partial for the backend form widget to use the FormBuilder, we'll have support for optGroup in our dropdowns.

Example result with mixed formats:
<img width="1012" height="499" alt="image" src="https://github.com/user-attachments/assets/5ae1ab80-8495-4837-a32e-93f02ab007d6" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select options can include per-item icons or images exposed via data attributes; optgroups support mixed item types.

* **Bug Fixes / Behavior Changes**
  * Improved detection to distinguish optgroups from single options and handle array-form displays for option entries.

* **Compatibility**
  * Simple string options and existing selection behavior remain supported.

* **Tests**
  * Added tests for icons, images, optgroups, HTML escaping, and backward-compatibility scenarios.

* **Documentation**
  * Updated docs describing accepted select formats and icon vs. image detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->