### PR TITLE
Update our override of Laravel's attributesToArray()

### DIFF
--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1184,55 +1184,16 @@ class Model extends EloquentModel implements ModelInterface
             }
         }
 
-        /*
-         * Dates
-         */
-        foreach ($this->getDates() as $key) {
-            if (!isset($attributes[$key])) {
-                continue;
-            }
+        $attributes = $this->addDateAttributesToArray($attributes);
 
-            $attributes[$key] = $this->serializeDate(
-                $this->asDateTime($attributes[$key])
-            );
-        }
+        $attributes = $this->addMutatedAttributesToArray(
+            $attributes, $mutatedAttributes = $this->getMutatedAttributes()
+        );
 
-        /*
-         * Mutate
-         */
-        $mutatedAttributes = $this->getMutatedAttributes();
+        $attributes = $this->addCastAttributesToArray(
+            $attributes, $mutatedAttributes
+        );
 
-        foreach ($mutatedAttributes as $key) {
-            if (!array_key_exists($key, $attributes)) {
-                continue;
-            }
-
-            $attributes[$key] = $this->mutateAttributeForArray(
-                $key,
-                $attributes[$key]
-            );
-        }
-
-        /*
-         * Casts
-         */
-        foreach ($this->casts as $key => $value) {
-            if (
-                !array_key_exists($key, $attributes) ||
-                in_array($key, $mutatedAttributes)
-            ) {
-                continue;
-            }
-
-            $attributes[$key] = $this->castAttribute(
-                $key,
-                $attributes[$key]
-            );
-        }
-
-        /*
-         * Appends
-         */
         foreach ($this->getArrayableAppends() as $key) {
             $attributes[$key] = $this->mutateAttributeForArray($key, null);
         }

--- a/src/Database/Model.php
+++ b/src/Database/Model.php
@@ -1174,6 +1174,7 @@ class Model extends EloquentModel implements ModelInterface
     public function attributesToArray()
     {
         $attributes = $this->getArrayableAttributes();
+        $mutatedAttributes = $this->getMutatedAttributes();
 
         /*
          * Before Event
@@ -1186,13 +1187,9 @@ class Model extends EloquentModel implements ModelInterface
 
         $attributes = $this->addDateAttributesToArray($attributes);
 
-        $attributes = $this->addMutatedAttributesToArray(
-            $attributes, $mutatedAttributes = $this->getMutatedAttributes()
-        );
+        $attributes = $this->addMutatedAttributesToArray($attributes, $mutatedAttributes);
 
-        $attributes = $this->addCastAttributesToArray(
-            $attributes, $mutatedAttributes
-        );
+        $attributes = $this->addCastAttributesToArray($attributes, $mutatedAttributes);
 
         foreach ($this->getArrayableAppends() as $key) {
             $attributes[$key] = $this->mutateAttributeForArray($key, null);

--- a/tests/Database/AttributesToArrayTest.php
+++ b/tests/Database/AttributesToArrayTest.php
@@ -48,12 +48,18 @@ class AttributesToArrayTest extends DbTestCase
         $this->assertSame(['foo' => 'bar'], $model->attributesToArray()['jsondata']);
     }
 
+    /**
+     * The mutator deliberately returns a *valid* JSON string. If the $jsonable loop stopped
+     * skipping mutated attributes it would decode that string into an array, overriding the
+     * mutator's intent; a mutator returning a non-JSON value would mask the regression because
+     * json_decode() would fail and leave the value untouched either way.
+     */
     public function testJsonableAttributesAreSkippedWhenAMutatorExists()
     {
         $model = new TestModelAttributes();
         $model->setRawAttributes(['mutatedjson' => '{"foo":"bar"}']);
 
-        $this->assertSame('MUTATED', $model->attributesToArray()['mutatedjson']);
+        $this->assertSame('{"mutated":true}', $model->attributesToArray()['mutatedjson']);
     }
 
     //
@@ -305,7 +311,7 @@ class TestModelAttributes extends Model
 
     public function getMutatedjsonAttribute($value)
     {
-        return 'MUTATED';
+        return '{"mutated":true}';
     }
 
     public function getAppendedAttribute()

--- a/tests/Database/AttributesToArrayTest.php
+++ b/tests/Database/AttributesToArrayTest.php
@@ -1,0 +1,326 @@
+<?php
+
+namespace Tests\Database;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
+use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Winter\Storm\Database\Model;
+use Winter\Storm\Tests\DbTestCase;
+
+/**
+ * Tests for Winter\Storm\Database\Model::attributesToArray().
+ *
+ * Storm overrides this method purely so that it can fire the `model.beforeGetAttribute` and
+ * `model.getAttribute` events and decode `$jsonable` columns; everything else is delegated to
+ * Laravel. These tests pin both halves of that contract: the Winter specific behaviour that must
+ * survive any future re-sync with Laravel, and the cast handling that Storm's previous hand-rolled
+ * copy of Laravel's cast loops silently got wrong.
+ */
+class AttributesToArrayTest extends DbTestCase
+{
+    //
+    // Winter specific behaviour: $jsonable
+    //
+
+    public function testJsonableAttributesAreDecoded()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes(['jsondata' => '{"foo":"bar"}']);
+
+        $this->assertSame(['foo' => 'bar'], $model->attributesToArray()['jsondata']);
+    }
+
+    public function testJsonableAttributesWithInvalidJsonAreLeftAsStrings()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes(['jsondata' => 'not json at all']);
+
+        $this->assertSame('not json at all', $model->attributesToArray()['jsondata']);
+    }
+
+    public function testJsonableAttributesAreNotDoubleDecoded()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes(['jsondata' => ['foo' => 'bar']]);
+
+        $this->assertSame(['foo' => 'bar'], $model->attributesToArray()['jsondata']);
+    }
+
+    public function testJsonableAttributesAreSkippedWhenAMutatorExists()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes(['mutatedjson' => '{"foo":"bar"}']);
+
+        $this->assertSame('MUTATED', $model->attributesToArray()['mutatedjson']);
+    }
+
+    //
+    // Winter specific behaviour: attribute events
+    //
+
+    public function testBeforeGetAttributeEventCanOverrideValues()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes(['name' => 'original', 'other' => 'untouched']);
+
+        $model->bindEvent('model.beforeGetAttribute', function ($key) {
+            return $key === 'name' ? 'overridden' : null;
+        });
+
+        $attributes = $model->attributesToArray();
+
+        $this->assertSame('overridden', $attributes['name']);
+        $this->assertSame('untouched', $attributes['other']);
+    }
+
+    public function testGetAttributeEventCanOverrideValues()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes(['name' => 'original', 'other' => 'untouched']);
+
+        $model->bindEvent('model.getAttribute', function ($key, $value) {
+            return $key === 'name' ? 'overridden' : null;
+        });
+
+        $attributes = $model->attributesToArray();
+
+        $this->assertSame('overridden', $attributes['name']);
+        $this->assertSame('untouched', $attributes['other']);
+    }
+
+    /**
+     * The `model.getAttribute` event must fire *after* dates, mutators, casts, appends and jsonable
+     * decoding have all been applied, so that listeners observe the final serialized value rather
+     * than the raw attribute. Reordering the pipeline would silently change what plugins receive.
+     */
+    public function testGetAttributeEventReceivesFullyProcessedValues()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes([
+            'dt' => '2025-01-01 00:00:00',
+            'jsondata' => '{"foo":"bar"}',
+            'mutated' => 'raw',
+        ]);
+
+        $seen = [];
+
+        $model->bindEvent('model.getAttribute', function ($key, $value) use (&$seen) {
+            $seen[$key] = $value;
+        });
+
+        $model->attributesToArray();
+
+        $this->assertSame('2025-01-01T00:00:00.000000Z', $seen['dt']);
+        $this->assertSame(['foo' => 'bar'], $seen['jsondata']);
+        $this->assertSame('MUT:raw', $seen['mutated']);
+        $this->assertSame('APPENDED', $seen['appended']);
+    }
+
+    //
+    // Cast handling
+    //
+
+    /**
+     * Pure (non-backed) enums have no default JSON representation, so leaving the enum instance in
+     * the array caused `toJson()` to throw outright.
+     */
+    public function testPureEnumCastsAreSerialized()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes(['pureenum' => 'Live']);
+
+        $this->assertSame('Live', $model->attributesToArray()['pureenum']);
+
+        // Would previously throw: "Non-backed enums have no default serialization".
+        $this->assertSame('Live', json_decode($model->toJson(), true)['pureenum']);
+    }
+
+    public function testBackedEnumCastsAreConvertedToScalars()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes(['backedenum' => 'live']);
+
+        $this->assertSame('live', $model->attributesToArray()['backedenum']);
+    }
+
+    /**
+     * Casts implementing SerializesCastableAttributes must have their serialize() method honoured
+     * rather than the raw value object being left in the array.
+     */
+    public function testSerializableCastsUseTheirSerializeMethod()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes(['money' => '1250']);
+
+        $this->assertInstanceOf(TestMoneyValue::class, $model->money);
+        $this->assertSame('SERIALIZED:1250', $model->attributesToArray()['money']);
+    }
+
+    /**
+     * Arrayable casts must be flattened, otherwise attributesToArray() returns a nested object and
+     * breaks its own contract of returning a plain array.
+     */
+    public function testArrayableCastsAreConvertedToArrays()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes([
+            'collection' => '{"foo":"bar"}',
+            'arrayobject' => '{"baz":"qux"}',
+        ]);
+
+        $attributes = $model->attributesToArray();
+
+        $this->assertIsArray($attributes['collection']);
+        $this->assertSame(['foo' => 'bar'], $attributes['collection']);
+        $this->assertIsArray($attributes['arrayobject']);
+        $this->assertSame(['baz' => 'qux'], $attributes['arrayobject']);
+    }
+
+    /**
+     * The implicit primary key cast comes from getCasts(), not the raw $casts property. Iterating
+     * the latter meant $model->id and $model->toArray()['id'] disagreed on any driver that returns
+     * column values as strings.
+     */
+    public function testPrimaryKeyCastMatchesTheAttributeAccessor()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes(['id' => '5']);
+
+        $this->assertSame(5, $model->id);
+        $this->assertSame(5, $model->attributesToArray()['id']);
+    }
+
+    public function testNonIncrementingModelsDoNotCastTheirPrimaryKey()
+    {
+        $model = new TestModelNonIncrementing();
+        $model->setRawAttributes(['id' => '5']);
+
+        $this->assertSame('5', $model->attributesToArray()['id']);
+    }
+
+    //
+    // Boundaries
+    //
+
+    public function testNullCastValuesRemainNull()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes([
+            'dt' => null,
+            'backedenum' => null,
+            'collection' => null,
+            'money' => null,
+        ]);
+
+        $attributes = $model->attributesToArray();
+
+        $this->assertNull($attributes['dt']);
+        $this->assertNull($attributes['backedenum']);
+        $this->assertNull($attributes['collection']);
+        $this->assertNull($attributes['money']);
+    }
+
+    public function testMutatorsTakePrecedenceOverCasts()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes(['mutated' => 'raw']);
+
+        $this->assertSame('MUT:raw', $model->attributesToArray()['mutated']);
+    }
+
+    public function testAppendedAttributesAreIncluded()
+    {
+        $model = new TestModelAttributes();
+        $model->setRawAttributes([]);
+
+        $this->assertSame('APPENDED', $model->attributesToArray()['appended']);
+    }
+}
+
+enum TestPureStatus
+{
+    case Draft;
+    case Live;
+}
+
+enum TestBackedStatus: string
+{
+    case Draft = 'draft';
+    case Live = 'live';
+}
+
+class TestMoneyValue
+{
+    public function __construct(public int $cents)
+    {
+    }
+}
+
+class TestMoneyCast implements CastsAttributes, SerializesCastableAttributes
+{
+    public function get($model, $key, $value, $attributes)
+    {
+        return is_null($value) ? null : new TestMoneyValue((int) $value);
+    }
+
+    public function set($model, $key, $value, $attributes)
+    {
+        return [$key => $value instanceof TestMoneyValue ? $value->cents : $value];
+    }
+
+    public function serialize($model, string $key, $value, array $attributes)
+    {
+        return 'SERIALIZED:' . $value->cents;
+    }
+}
+
+class TestModelAttributes extends Model
+{
+    public $table = 'test_model';
+
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    protected $jsonable = ['jsondata', 'mutatedjson'];
+
+    protected $appends = ['appended'];
+
+    protected $casts = [
+        'dt' => 'datetime',
+        'pureenum' => TestPureStatus::class,
+        'backedenum' => TestBackedStatus::class,
+        'money' => TestMoneyCast::class,
+        'collection' => AsCollection::class,
+        'arrayobject' => AsArrayObject::class,
+        'mutated' => 'integer',
+    ];
+
+    public function getMutatedAttribute($value)
+    {
+        return 'MUT:' . $value;
+    }
+
+    public function getMutatedjsonAttribute($value)
+    {
+        return 'MUTATED';
+    }
+
+    public function getAppendedAttribute()
+    {
+        return 'APPENDED';
+    }
+}
+
+class TestModelNonIncrementing extends Model
+{
+    public $table = 'test_model';
+
+    public $timestamps = false;
+
+    public $incrementing = false;
+
+    protected $guarded = [];
+}

--- a/tests/Database/ModelTest.php
+++ b/tests/Database/ModelTest.php
@@ -489,7 +489,8 @@ class ModelTest extends DbTestCase
         $this->assertInstanceOf(\Winter\Storm\Argon\Argon::class, $model->updated_at);
         $this->assertInstanceOf(\Winter\Storm\Argon\Argon::class, $model->deleted_at);
 
-        $this->assertEquals([
+        $this->assertEquals(
+            [
                 'created_at' => '2025/10/31',
                 'updated_at' => '2025_12_31 @ 23:59',
                 'deleted_at' => '2026-01-01T00:00:00.000000Z',

--- a/tests/Database/ModelTest.php
+++ b/tests/Database/ModelTest.php
@@ -470,6 +470,34 @@ class ModelTest extends DbTestCase
         $this->assertEquals(['id' => 'int', 'foo' => 'int'], $model->getCasts());
     }
 
+    public function testAddDatesCasts()
+    {
+        $model = new TestModelGuarded();
+        $model->timestamps = false;
+
+        $model->addCasts([
+            'created_at' => 'date:Y/m/d',
+            'updated_at' => 'datetime:Y_m_d @ H:i',
+            'deleted_at' => 'date',
+        ]);
+
+        $model->created_at = '2025-10-31 22:50:55';
+        $model->updated_at = '2025-12-31 23:59:59';
+        $model->deleted_at = '2026-01-01 12:13:14';
+
+        $this->assertInstanceOf(\Winter\Storm\Argon\Argon::class, $model->created_at);
+        $this->assertInstanceOf(\Winter\Storm\Argon\Argon::class, $model->updated_at);
+        $this->assertInstanceOf(\Winter\Storm\Argon\Argon::class, $model->deleted_at);
+
+        $this->assertEquals([
+                'created_at' => '2025/10/31',
+                'updated_at' => '2025_12_31 @ 23:59',
+                'deleted_at' => '2026-01-01T00:00:00.000000Z',
+            ],
+            $model->attributesToArray()
+        );
+    }
+
     public function testStringIsTrimmed()
     {
         $name = "Name";


### PR DESCRIPTION
## Why

Storm overrides `attributesToArray()` so it can fire the `model.beforeGetAttribute` / `model.getAttribute` events and decode `$jsonable` columns. To do that, the override hand-copied Laravel's date / mutator / cast loops inline.

That copy was taken from an old version of Laravel and never kept in sync. Laravel has since moved the cast handling into `addDateAttributesToArray()` / `addMutatedAttributesToArray()` / `addCastAttributesToArray()` and added a whole post-cast serialization step that our copy simply doesn't have. The result is that several documented Laravel cast behaviours are silently broken — or outright fatal — on Winter models.

This PR keeps the Winter-specific bits (both events, `$jsonable`, `$appends`, and the existing ordering) and delegates the rest to the base model, deleting ~46 lines of stale duplication.

## What this actually fixes

Verified against a probe model exercising every cast type, before and after:

**1. Pure (non-backed) enum casts crash `toJson()`**

```php
enum Status { case Draft; case Live; }
protected $casts = ['status' => Status::class];
```

`toArray()` currently leaves the enum *instance* in the array, so encoding blows up:

```
JsonException: Non-backed enums have no default serialization
```

Laravel's `getStorableEnumValue()` handles this (`->value` for backed, `->name` for pure). After: `"status": "Live"`.

**2. `SerializesCastableAttributes::serialize()` is never called**

A custom cast implementing this interface is a documented Laravel contract, and we ignore it — the raw value object leaks into `toArray()` and JSON output becomes whatever the object's public properties happen to be (`{"cents":1250}` instead of the intended `"SERIALIZED:1250"`).

**3. `date:<format>` / `datetime:<format>` formats are silently ignored**

```php
protected $casts = ['published_at' => 'datetime:Y/m/d'];
```

Currently emits the full ISO-8601 string in `toArray()`/`toJson()` — the requested format is dropped without warning. After: `2025/12/31`.

**4. `AsCollection` / `AsArrayObject` / `AsEncryptedCollection` leak objects**

`toArray()` returns a `Collection` / `ArrayObject` nested inside the array, so the method doesn't honour its own contract of returning a plain array. Anything doing `array_walk_recursive()`, strict comparison, or plain array traversal over the result hits an object. Laravel's `Arrayable` check flattens these.

**5. `toArray()['id']` disagrees with `$model->id`**

`getAttribute()` already applies the implicit primary-key cast via `getCasts()`, but our loop iterated the raw `$this->casts` property, which doesn't include it. On any driver/config that returns column values as strings, that means:

```php
$model->id;                  // int(5)
$model->toArray()['id'];     // string("5")   ->  API sends {"id":"5"}
```

Two different types for the same attribute, which is a reliable source of strict-equality bugs in front-end code consuming the JSON.

**6. Maintenance**

Every future Laravel cast feature currently requires a manual re-port into our override, and the omissions above are exactly what happens when that doesn't occur. Delegating to the base model means we inherit them going forward.

## Compatibility notes

- **JSON output is unchanged** except in the broken cases above (pure enums, `SerializesCastableAttributes`, custom date formats, and `id` on string-returning drivers).
- **`toArray()` value *types* do change** where a cast is declared: `datetime`/`date` casts now yield the serialized string rather than an `Argon` instance, `AsCollection` yields an array rather than a `Collection`, and enum casts yield the scalar. This matches upstream Laravel. Code doing `$model->toArray()['some_datetime_cast']->format(...)` will need updating — worth an upgrade note.
- **Ordinary timestamps are unaffected.** `created_at`/`updated_at` are covered by `getDates()` and were already serialized to strings before this change.
- Models declaring no `$casts` see no change at all.

## Known edge case

When a column appears in **both** `getDates()` and a custom-format cast, `addDateAttributesToArray()` serializes it to UTC ISO-8601 first, and `addCastAttributesToArray()` then re-parses and formats that UTC value — so the custom format renders in UTC rather than the app timezone. This is inherited from Laravel rather than introduced here, but it's why the new test sets `$timestamps = false` in order to use `created_at`/`updated_at` in `$casts`.

## Testing

- Adds `testAddDatesCasts()` covering `date:<format>`, `datetime:<format>` and bare `date` casts.
- Full Storm suite: no new failures (the pre-existing `ArrayFileTest` / `ConfigWriterTest` formatting failures on `develop` are unrelated).
- Full Winter CMS core suite passes against a patched Storm; core itself declares no `$casts` outside the model stub, so there is no internal exposure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined attribute transformation so date handling, mutations, and casts are processed consistently via centralized routines.

* **Tests**
  * Expanded coverage for attribute serialization, including date/cast formatting and validation of resulting attribute output.
  * Added a comprehensive test suite for `attributesToArray()` behavior, covering JSON decoding rules, correct precedence between mutators and casts, enum/cast serialization, arrayable casts, primary-key casting, null preservation, and appended attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
