### PR TITLE
Prevent exception when dynamically extending a class to add behaviors.

### DIFF
--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -489,7 +489,7 @@ trait ExtendableTrait
                     throw new Exception(sprintf('Class %s contains an invalid $implement value', $className));
                 }
 
-                foreach ($uses as $use) {
+                foreach (array_unique($uses) as $use) {
                     // Class alias checks not required here as the current name of the extension class doesn't
                     // matter because as long as $useClassName is able to be instantiated the method will resolve
                     $useClassName = str_replace('.', '\\', trim($use));

--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -84,7 +84,7 @@ trait ExtendableTrait
             return;
         }
 
-        foreach ($uses as $use) {
+        foreach (array_unique($uses) as $use) {
             $useClass = $this->extensionNormalizeClassName($use);
 
             /*


### PR DESCRIPTION
Fixes https://github.com/wintercms/winter/issues/1460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the same extension could be applied multiple times; extensions are now applied once.
  * This reduces redundant processing and prevents unintended duplicate behavior, improving reliability and consistency when multiple identical extensions are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->