### PR TITLE
Implement typeTinyint for SQLite grammar

### DIFF
--- a/src/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Database/Schema/Grammars/SQLiteGrammar.php
@@ -156,6 +156,21 @@ class SQLiteGrammar extends BaseSQLiteGrammar
 
         return parent::getDefaultValue($value);
     }
+    
+    /**
+     * Create the column definition for a tinyint type.
+     *
+     * SQLite's column introspection returns 'tinyint' as the type_name for boolean and tinyInteger
+     * columns. The base grammar only has typeTinyInteger, so we need this alias to avoid
+     * BadMethodCallException when compileChange rebuilds a table that contains boolean columns.
+     *
+     * @param  \Illuminate\Support\Fluent  $column
+     * @return string
+     */
+    protected function typeTinyint(Fluent $column)
+    {
+        return 'integer';
+    }
 
     /**
      * Create the column definition for a varchar type.

--- a/src/Database/Schema/Grammars/SQLiteGrammar.php
+++ b/src/Database/Schema/Grammars/SQLiteGrammar.php
@@ -156,7 +156,7 @@ class SQLiteGrammar extends BaseSQLiteGrammar
 
         return parent::getDefaultValue($value);
     }
-    
+
     /**
      * Create the column definition for a tinyint type.
      *

--- a/tests/Database/Schema/Grammars/SQLiteSchemaGrammarTest.php
+++ b/tests/Database/Schema/Grammars/SQLiteSchemaGrammarTest.php
@@ -79,7 +79,7 @@ class SQLiteSchemaGrammarTest extends GrammarTestCase
         // BadMethodCallException: Method SQLiteGrammar::typeTinyint does not exist
         $statements = $blueprint->toSql();
 
-        // compileChange maps 'tinyint' (SQLite's introspected type_name) to 'integer'.
+        // compileChange maps 'tinyint' (SQLite's introspected type_name) to 'integer'
         $this->assertNotEmpty($statements);
         $this->assertStringContainsString('"is_active" integer', $statements[0]);
     }

--- a/tests/Database/Schema/Grammars/SQLiteSchemaGrammarTest.php
+++ b/tests/Database/Schema/Grammars/SQLiteSchemaGrammarTest.php
@@ -2,11 +2,13 @@
 
 namespace Winter\Storm\Tests\Database\Schema\Grammars;
 
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\SQLiteBuilder;
+use Illuminate\Database\SQLiteConnection;
 use Winter\Storm\Database\Schema\Grammars\SQLiteGrammar;
 use Winter\Storm\Tests\GrammarTestCase;
 
-class SQLiteSchemaGrammarTest extends \Winter\Storm\Tests\GrammarTestCase
+class SQLiteSchemaGrammarTest extends GrammarTestCase
 {
     public function setUp(): void
     {
@@ -59,5 +61,26 @@ class SQLiteSchemaGrammarTest extends \Winter\Storm\Tests\GrammarTestCase
 
         $statements = $this->runBlueprint($changedBlueprint);
         $this->assertStringContainsString("\"name\" varchar not null default 'admin'", $statements[0]);
+    }
+
+    public function testTypeTinyintTypeIsValid(): void
+    {
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->exec('CREATE TABLE users (is_active tinyint not null, name varchar not null)');
+
+        $connection = new SQLiteConnection($pdo, ':memory:', '');
+        $grammar = new SQLiteGrammar($connection);
+        $connection->setSchemaGrammar($grammar);
+
+        $blueprint = new Blueprint($connection, 'users');
+        $blueprint->string('name')->nullable()->change();
+
+        // Prior to the typeTinyint fix, this would throw:
+        // BadMethodCallException: Method SQLiteGrammar::typeTinyint does not exist
+        $statements = $blueprint->toSql();
+
+        // compileChange maps 'tinyint' (SQLite's introspected type_name) to 'integer'.
+        $this->assertNotEmpty($statements);
+        $this->assertStringContainsString('"is_active" integer', $statements[0]);
     }
 }


### PR DESCRIPTION
The `compileChange` override in `vendor/winter/storm/src/Database/Schema/Grammars/SQLiteGrammar.php` reads SQLite column type names as tinyint (from SQLite metadata for boolean columns), then calls getType() which looks for `->typeTinyint(...` — but only typeTinyInteger exists in the base grammar file `Illuminate\Database\Schema\Grammars\SQLiteGrammar`.

This should resolve migration issues others might hit when upgrading to 1.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQLite schema operations now correctly handle tinyint column types, eliminating errors during column introspection and reconstruction.

* **Tests**
  * Added validation tests for tinyint column type mapping in SQLite, ensuring proper SQL generation for schema operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->