### PR TITLE
Add PHP 8.5 to the test matrix and fix PHP 8.5 deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       max-parallel: 6
       matrix:
         operatingSystem: [ubuntu-latest, windows-latest]
-        phpVersion: ['8.1', '8.2', '8.3', '8.4']
+        phpVersion: ['8.1', '8.2', '8.3', '8.4', '8.5']
       fail-fast: false
     runs-on: ${{ matrix.operatingSystem }}
     name: ${{ matrix.operatingSystem }} / PHP ${{ matrix.phpVersion }}

--- a/src/Config/Repository.php
+++ b/src/Config/Repository.php
@@ -194,7 +194,7 @@ class Repository extends BaseRepository implements ArrayAccess, RepositoryContra
         // If we've already loaded this collection, we will just bail out since we do
         // not want to load it again. Once items are loaded a first time they will
         // stay kept in memory within this class and not loaded from disk again.
-        if (isset($this->afterLoad[$namespace])) {
+        if ($namespace !== null && isset($this->afterLoad[$namespace])) {
             $items = $this->callAfterLoad($namespace, $group, $items);
         }
 

--- a/src/Console/Traits/ProcessesQuery.php
+++ b/src/Console/Traits/ProcessesQuery.php
@@ -16,7 +16,7 @@ trait ProcessesQuery
      * query by the provided chunkSize, running the callback on each record and
      * limiting number of records processed to the provided limit
      */
-    public function processQuery(Builder $query, callable $callback, int $chunkSize = 100, int $limit = null): void
+    public function processQuery(Builder $query, callable $callback, int $chunkSize = 100, ?int $limit = null): void
     {
         $totalRecords = $query->count();
 

--- a/src/Network/Http.php
+++ b/src/Network/Http.php
@@ -368,7 +368,7 @@ class Http
         /*
          * Close resources
          */
-        curl_close($curl);
+        unset($curl);
 
         if ($this->streamFile) {
             rewind($headerStream);


### PR DESCRIPTION
Adds PHP 8.5 to the unit test matrix on both Ubuntu and Windows, and fixes the PHP 8.5 deprecations in Storm code that the new matrix entry surfaces:

- `src/Network/Http.php` — `curl_close()` is deprecated since 8.5 (it has been a no-op since PHP 8.0, when curl handles became `CurlHandle` objects). Replaced with `unset()` to keep the early-release intent.
- `src/Config/Repository.php` — `isset($this->afterLoad[$namespace])` is hit with `$namespace = null` for every non-namespaced config key, and null array offsets are deprecated since 8.5. Added an explicit null check; behaviour is unchanged (the old null→`""` coercion could never match a registered callback, since `afterLoading()` is always called with a string namespace).
- `src/Console/Traits/ProcessesQuery.php` — implicitly nullable `int $limit = null` parameter is deprecated; made it explicitly `?int`.

After these fixes, a `php -l` sweep of `src/` on 8.5 reports no compile-time deprecations, and the full test suite emits none at runtime either.

Verified locally on PHP 8.5.5 and 8.4.14 against current `develop` (identical results on both):

```
OK, but incomplete, skipped, or risky tests!
Tests: 701, Assertions: 3085, Skipped: 9.
```

`phpcs` and `phpstan analyse` are clean on the changed files.

Note: until orchestral/testbench-core#415 (submitted separately) is merged and tagged, one remaining deprecation notice from the vendored testbench skeleton (`PDO::MYSQL_ATTR_SSL_CA`) will still appear in 8.5 test output. It is non-fatal and outside Storm's control.