### PR TITLE
Cache reflection lookups in ExtendableTrait magic method handling

### DIFF
--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -50,6 +50,21 @@ trait ExtendableTrait
     protected static $extendableClassLoader = null;
 
     /**
+     * @var array Cache of parent class reflections (or `false` when there is none), keyed by class name.
+     */
+    protected static $extensionParentClassCache = [];
+
+    /**
+     * @var array Cache of magic method reflections (or `false` when unavailable), keyed by "Class::method".
+     */
+    protected static $extensionMethodReflectionCache = [];
+
+    /**
+     * @var array Cache of property accessibility checks, keyed by class name and property name.
+     */
+    protected static $extensionAccessiblePropertyCache = [];
+
+    /**
      * This method should be called as part of the constructor.
      */
     public function extendableConstruct()
@@ -349,9 +364,10 @@ trait ExtendableTrait
      */
     protected function extendableIsAccessible($class, $propertyName)
     {
-        $reflector = new ReflectionClass($class);
-        $property = $reflector->getProperty($propertyName);
-        return $property->isPublic();
+        $className = is_object($class) ? get_class($class) : $class;
+
+        return self::$extensionAccessiblePropertyCache[$className][$propertyName]
+            ??= (new ReflectionClass($class))->getProperty($propertyName)->isPublic();
     }
 
     /**
@@ -554,12 +570,32 @@ trait ExtendableTrait
             return false;
         }
 
-        // Find if any parent uses the Extendable trait
+        // Intermediate steps of the recursive resolution are not cached.
         if (!is_null($instance)) {
-            $reflector = $instance;
-        } else {
-            $reflector = new ReflectionClass($this);
+            return $this->extensionResolveParentClass($instance);
         }
+
+        // The resolution depends only on the class, so cache it per class to avoid repeating the
+        // reflection walk on every magic method call.
+        $className = static::class;
+
+        if (!array_key_exists($className, self::$extensionParentClassCache)) {
+            self::$extensionParentClassCache[$className] = $this->extensionResolveParentClass(
+                new ReflectionClass($this)
+            );
+        }
+
+        return self::$extensionParentClassCache[$className];
+    }
+
+    /**
+     * Resolves the first parent class that does not use the Extendable trait.
+     *
+     * @return ReflectionClass|false
+     */
+    protected function extensionResolveParentClass(object $reflector)
+    {
+        // Find if any parent uses the Extendable trait
         $parent = $reflector->getParentClass();
 
         // If there's no parent, stop here.
@@ -583,7 +619,7 @@ trait ExtendableTrait
         }
 
         // Otherwise, we need to loop through until we find the parent class that doesn't use the Extendable trait
-        return $this->extensionGetParentClass($parent);
+        return $this->extensionResolveParentClass($parent);
     }
 
     /**
@@ -591,17 +627,30 @@ trait ExtendableTrait
      */
     protected function extensionMethodExists(ReflectionClass $class, string $methodName): bool
     {
-        try {
-            $method = $class->getMethod($methodName);
+        return $this->extensionGetMethodReflection($class, $methodName) !== false;
+    }
 
-            if (!$method->isPublic()) {
-                return false;
+    /**
+     * Gets the reflection for a public method on the given class reflection, or `false` if the method is
+     * unavailable. The result is cached per class, as it cannot change at runtime.
+     *
+     * @return ReflectionMethod|false
+     */
+    protected function extensionGetMethodReflection(ReflectionClass $class, string $methodName)
+    {
+        $cacheKey = $class->getName() . '::' . $methodName;
+
+        if (!array_key_exists($cacheKey, self::$extensionMethodReflectionCache)) {
+            try {
+                $method = $class->getMethod($methodName);
+
+                self::$extensionMethodReflectionCache[$cacheKey] = $method->isPublic() ? $method : false;
+            } catch (ReflectionException $e) {
+                self::$extensionMethodReflectionCache[$cacheKey] = false;
             }
-        } catch (ReflectionException $e) {
-            return false;
         }
 
-        return true;
+        return self::$extensionMethodReflectionCache[$cacheKey];
     }
 
     /**
@@ -609,7 +658,14 @@ trait ExtendableTrait
      */
     protected function extensionCallMethod(ReflectionClass $class, string $method, array $params)
     {
-        $method = $class->getMethod($method);
-        return $method->invokeArgs($this, $params);
+        $reflection = $this->extensionGetMethodReflection($class, $method);
+
+        // Fall back to an uncached reflection for non-public methods, retaining the previous behaviour
+        // of this method for direct calls that are not guarded by extensionMethodExists().
+        if ($reflection === false) {
+            $reflection = $class->getMethod($method);
+        }
+
+        return $reflection->invokeArgs($this, $params);
     }
 }

--- a/tests/Extension/ExtendableTraitTest.php
+++ b/tests/Extension/ExtendableTraitTest.php
@@ -42,6 +42,58 @@ class ExtendableTraitTest extends TestCase
         $this->assertEquals(Level1NonExtendable::class, $this->callProtectedMethod($level2NonExtendable, 'extensionGetParentClass')->getName());
         $this->assertEquals(Level1NonExtendable::class, $this->callProtectedMethod($level3NonExtendable, 'extensionGetParentClass')->getName());
     }
+
+    /**
+     * @testdox will reuse the parent class reflection across calls and instances of the same class
+     *
+     * The parent class resolution depends only on the class, so the reflection should be resolved once per class
+     * instead of being rebuilt on every magic method call.
+     */
+    public function testParentClassReflectionIsMemoized()
+    {
+        $level2 = new Level2NonExtendable;
+
+        $first = $this->callProtectedMethod($level2, 'extensionGetParentClass');
+        $second = $this->callProtectedMethod($level2, 'extensionGetParentClass');
+
+        $this->assertInstanceOf(\ReflectionClass::class, $first);
+        $this->assertSame($first, $second);
+
+        // Instances of the same class share the resolved reflection
+        $third = $this->callProtectedMethod(new Level2NonExtendable, 'extensionGetParentClass');
+        $this->assertSame($first, $third);
+
+        // Subclasses are memoized under their own class and still resolve correctly
+        $level3First = $this->callProtectedMethod(new Level3NonExtendable, 'extensionGetParentClass');
+        $level3Second = $this->callProtectedMethod(new Level3NonExtendable, 'extensionGetParentClass');
+
+        $this->assertEquals(Level1NonExtendable::class, $level3First->getName());
+        $this->assertSame($level3First, $level3Second);
+    }
+
+    /**
+     * @testdox routes magic methods consistently across repeated calls and instances
+     */
+    public function testRepeatedMagicAccessBehavesConsistently()
+    {
+        $a = new Level2NonExtendable;
+        $b = new Level2NonExtendable;
+
+        // No parent __get exists, so undefined properties resolve to null - repeatedly
+        $this->assertNull($a->undefinedProperty);
+        $this->assertNull($a->undefinedProperty);
+        $this->assertNull($b->undefinedProperty);
+
+        // Undefined methods throw consistently on every call
+        foreach ([$a, $b, $a] as $instance) {
+            try {
+                $instance->undefinedMethod();
+                $this->fail('Expected BadMethodCallException was not thrown');
+            } catch (\BadMethodCallException $e) {
+                $this->assertStringContainsString('undefinedMethod', $e->getMessage());
+            }
+        }
+    }
 }
 
 class ExtendableRoot extends Extendable


### PR DESCRIPTION
## Problem

Every `__get`/`__set`/`__call` on a class using `ExtendableTrait` (i.e. every attribute access on every Database model) currently:

- builds a fresh `ReflectionClass` and recursively walks the parent chain in `extensionGetParentClass()` to find the first non-extendable ancestor,
- resolves the parent's `__get`/`__set`/`__call` `ReflectionMethod` **twice** per call — once in `extensionMethodExists()` and again in `extensionCallMethod()`,
- and, for classes with behaviors, constructs another `ReflectionClass` per extension per property read in `extendableIsAccessible()`.

None of this was memoized, although every one of these resolutions depends only on the class, never the instance. A microbenchmark of the `__get` path shows roughly a 10x overhead per attribute access (~30ns direct vs ~340ns through the reflection path) — and a typical request makes thousands of magic-method calls through models, components and widgets, plus GC pressure from the throwaway reflection objects.

## Fix

Three per-class static caches, following the same pattern as the existing `extendableCallStatic()` cache in the same file:

- `extensionGetParentClass()` caches the resolved parent reflection (or `false`) per class; the recursion's intermediate steps are split into `extensionResolveParentClass()` and are not cached.
- `extensionMethodExists()` / `extensionCallMethod()` share a cached `ReflectionMethod` handle per class and method. `extensionCallMethod()` keeps a fallback to an uncached `getMethod()` for non-public methods so its behaviour for direct, unguarded calls is unchanged (including the `ReflectionException` for unknown methods).
- `extendableIsAccessible()` caches the visibility check per class and property.

All cached values are class-structure facts that cannot change at runtime, so there is no invalidation concern; dynamic methods and properties continue to live in the per-instance `$extensionData` and are checked before any of these paths.

## Testing

New tests assert the parent reflection is reused across calls and instances (and that subclasses memoize independently), and that repeated magic access behaves consistently across instances. The full test suite passes — the Database model tests exercise the cached `__get`/`__set`/`__call` paths heavily.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application performance through internal optimization.
  * Enhanced reliability and consistency of magic method and property access behavior.

* **Tests**
  * Added comprehensive tests for magic method and property access patterns to ensure consistent behavior across repeated operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->