### PR TITLE
Fix CI: regenerate stale PHPStan baseline and code-quality drift

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,6 +13,12 @@ parameters:
 			path: src/Auth/Models/Group.php
 
 		-
+			message: '#^Method Winter\\Storm\\Auth\\Models\\Preferences\:\:findRecord\(\) should return Winter\\Storm\\Auth\\Models\\Preferences\|null but returns stdClass\|null\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Auth/Models/Preferences.php
+
+		-
 			message: '#^Call to an undefined method \$this\(Winter\\Storm\\Auth\\Models\\Role\)\:\:getOriginalEncryptableValues\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -27,24 +33,6 @@ parameters:
 		-
 			message: '#^Call to an undefined method \$this\(Winter\\Storm\\Auth\\Models\\User\)\:\:getOriginalEncryptableValues\(\)\.$#'
 			identifier: method.notFound
-			count: 1
-			path: src/Auth/Models/User.php
-
-		-
-			message: '#^Call to function method_exists\(\) with \$this\(Winter\\Storm\\Auth\\Models\\User\) and ''getHashableAttribut…'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Auth/Models/User.php
-
-		-
-			message: '#^Call to function property_exists\(\) with \$this\(Winter\\Storm\\Auth\\Models\\User\) and ''attributeNames'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Auth/Models/User.php
-
-		-
-			message: '#^Call to function property_exists\(\) with \$this\(Winter\\Storm\\Auth\\Models\\User\) and ''customMessages'' will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Auth/Models/User.php
 
@@ -183,6 +171,54 @@ parameters:
 		-
 			message: '#^Method Winter\\Storm\\Database\\Model\:\:newMorphToMany\(\) should return Illuminate\\Database\\Eloquent\\Relations\\MorphToMany\<TRelatedModel of Illuminate\\Database\\Eloquent\\Model, TDeclaringModel of Illuminate\\Database\\Eloquent\\Model, Illuminate\\Database\\Eloquent\\Relations\\MorphPivot, ''pivot''\> but returns Winter\\Storm\\Database\\Relations\\MorphToMany\.$#'
 			identifier: return.type
+			count: 1
+			path: src/Database/Model.php
+
+		-
+			message: '#^Parameter \#1 \$query of class Winter\\Storm\\Database\\Relations\\BelongsTo constructor expects Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>, Illuminate\\Database\\Eloquent\\Builder\<TRelatedModel of Illuminate\\Database\\Eloquent\\Model\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Database/Model.php
+
+		-
+			message: '#^Parameter \#1 \$query of class Winter\\Storm\\Database\\Relations\\BelongsToMany constructor expects Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>, Illuminate\\Database\\Eloquent\\Builder\<TRelatedModel of Illuminate\\Database\\Eloquent\\Model\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Database/Model.php
+
+		-
+			message: '#^Parameter \#1 \$query of class Winter\\Storm\\Database\\Relations\\HasMany constructor expects Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>, Illuminate\\Database\\Eloquent\\Builder\<TRelatedModel of Illuminate\\Database\\Eloquent\\Model\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Database/Model.php
+
+		-
+			message: '#^Parameter \#1 \$query of class Winter\\Storm\\Database\\Relations\\HasManyThrough constructor expects Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>, Illuminate\\Database\\Eloquent\\Builder\<TRelatedModel of Illuminate\\Database\\Eloquent\\Model\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Database/Model.php
+
+		-
+			message: '#^Parameter \#1 \$query of class Winter\\Storm\\Database\\Relations\\HasOne constructor expects Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>, Illuminate\\Database\\Eloquent\\Builder\<TRelatedModel of Illuminate\\Database\\Eloquent\\Model\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Database/Model.php
+
+		-
+			message: '#^Parameter \#1 \$query of class Winter\\Storm\\Database\\Relations\\HasOneThrough constructor expects Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>, Illuminate\\Database\\Eloquent\\Builder\<TRelatedModel of Illuminate\\Database\\Eloquent\\Model\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Database/Model.php
+
+		-
+			message: '#^Parameter \#1 \$query of class Winter\\Storm\\Database\\Relations\\MorphTo constructor expects Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>, Illuminate\\Database\\Eloquent\\Builder\<TRelatedModel of Illuminate\\Database\\Eloquent\\Model\> given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Database/Model.php
+
+		-
+			message: '#^Parameter \#1 \$query of class Winter\\Storm\\Database\\Relations\\MorphToMany constructor expects Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>, Illuminate\\Database\\Eloquent\\Builder\<TRelatedModel of Illuminate\\Database\\Eloquent\\Model\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Database/Model.php
 
@@ -643,12 +679,6 @@ parameters:
 			path: src/Database/Relations/HasOneThrough.php
 
 		-
-			message: '#^Instanceof between \*NEVER\* and Winter\\Storm\\Database\\Relations\\HasManyThrough will always evaluate to false\.$#'
-			identifier: instanceof.alwaysFalse
-			count: 4
-			path: src/Database/Relations/HasOneThrough.php
-
-		-
 			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\Relation\:\:withDefault\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -959,6 +989,12 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: src/Database/TreeCollection.php
+
+		-
+			message: '#^Call to function is_array\(\) with array will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/Events/Dispatcher.php
 
 		-
 			message: '#^Call to an undefined method Illuminate\\Routing\\Router\:\:after\(\)\.$#'

--- a/src/Filesystem/FilesystemServiceProvider.php
+++ b/src/Filesystem/FilesystemServiceProvider.php
@@ -26,11 +26,9 @@ class FilesystemServiceProvider extends FilesystemServiceProviderBase
     protected function extendFilesystemAdapter()
     {
         FilesystemAdapter::macro('getPathPrefix', function () {
-            /** @phpstan-ignore-next-line */
             return $this->prefixer->prefixPath('');
         });
         FilesystemAdapter::macro('setPathPrefix', function (string $prefix) {
-            /** @phpstan-ignore-next-line */
             $this->prefixer = new PathPrefixer($prefix, $this->config['directory_separator'] ?? DIRECTORY_SEPARATOR);
         });
     }

--- a/tests/Parse/Assetic/LessCompilerTest.php
+++ b/tests/Parse/Assetic/LessCompilerTest.php
@@ -110,5 +110,4 @@ class LessCompilerTest extends \Winter\Storm\Tests\TestCase
         $compiler->filterLoad($asset);
         return $asset->getContent();
     }
-
 }


### PR DESCRIPTION
## What this fixes

CI on `wip/1.3` had drifted in two static-analysis dimensions. This PR restores the **Code Analysis (PHPStan)** and **Code Quality (PHPCS)** signals to green.

### 1. Stale `phpstan-baseline.neon` (Code Analysis job — PHP 8.4 / PHPStan 2.2.8)
Reproduced locally against the exact versions CI resolves (PHP 8.4.23, phpstan/phpstan 2.2.8, laravel/framework 12.65). The committed baseline produced **16 errors**:
- Stale `function.alreadyNarrowedType` ignore patterns (`src/Auth/Models/User.php`) that no longer occur.
- `ignore.unmatched` for patterns in `src/Auth/Models/User.php` and `src/Database/Relations/HasOneThrough.php`.
- New `argument.type` builder-covariance findings (`src/Database/Concerns/HasRelationships.php`) surfaced by the current Illuminate version.
- Two **non-baselineable** `ignore.unmatchedLine` errors in `src/Filesystem/FilesystemServiceProvider.php`.

Fix: regenerated the baseline with `composer baseline`. `phpstan analyse --memory-limit=2G` now reports **`[OK] No errors`**.

### 2. Stale inline ignores in `FilesystemServiceProvider`
The two `@phpstan-ignore-next-line` comments guarding `$this->prefixer` no longer match any reported error under the current Laravel version, so PHPStan itself reported them as errors (they can't be baselined). Removed them.

### 3. Pre-existing PHPCS violation
`tests/Parse/Assetic/LessCompilerTest.php` had a blank line before the class closing brace, failing `composer sniff`. Removed it. (Note: CI's `phpcs-pr` only diffs changed files so this didn't block the PR check, but `composer sniff` now passes cleanly.)

## Local verification (PHP 8.4.23)
- ✅ `phpstan analyse` — No errors
- ✅ `composer sniff` (PHPCS) — clean, exit 0
- ✅ `php -l` across all `src/` + `tests/` — no syntax errors (parallel-lint equivalent)
- ✅ PHPUnit — **839/839 non-SQLite-grammar tests pass**

## ⚠️ Not fixed here — needs maintainer action

**A) The Tests job has 2 pre-existing failures owned by #239.**
`tests/Database/Schema/Grammars/SQLiteSchemaGrammarTest`:
- `testNullableInitialModifierAddDefault`
- `testTypeTinyintTypeIsValid`

These fail on current `wip/1.3` and are exactly the SQLite `->change()` rebuild bug that **PR #239** fixes. Those tests and their source live entirely in #239's files, so this PR intentionally does **not** touch them. The Tests job cannot go fully green until #239 merges.

**B) Baseline overlap with #239 — sequencing note.**
The regenerated baseline still contains the 6 `src/Database/Schema/Grammars/SQLiteGrammar.php` entries that **#239 removes** (its baseline diff is `+0/-36`). This is the expected overlap. Recommended merge order: **this PR first**, then #239 (which will drop those now-obsolete entries as part of its grammar fix). Merging #239 first will leave 6 unmatched-baseline errors until this PR's regeneration is reconciled.

**C) Composer install auth failure (infra — not fixable in code).**
Every recent CI run on this repo (including #239's) fails `composer install` with `Failed to download winter/laravel-config-writer from dist: Could not authenticate against github.com` / "Source fallback is disabled". Dependency resolution succeeds; only the authenticated dist download fails — the classic symptom of an **expired/invalid `COMPOSER_GITHUB_TOKEN` repo secret**. This needs the token rotated in repo settings; it blocks the Tests and Code Analysis jobs regardless of code changes. (The `dms/phpunit-arraysubset-asserts:dev-add-phpunit-11-support` fork VCS repo is still genuinely required — upstream has no PHPUnit 11 release — so it can't be dropped to sidestep the auth path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)