### PR TITLE
Working toward Octane support: worker-safe primitives

### DIFF
--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -70,7 +70,12 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm
     protected $viaRemember = false;
 
     /**
-     * @var string The IP address of this request
+     * @var string|null The IP address of this request, or null when it has not been resolved yet.
+     *
+     * Read through resolveIpAddress() internally. Under a persistent application server the value
+     * is deliberately left unresolved at the operation boundary and derived on first use, because
+     * the boundary runs before the trusted-proxy middleware has told the request which addresses
+     * to believe — an eager capture there records the load balancer instead of the client.
      */
     public $ipAddress = '0.0.0.0';
 
@@ -432,7 +437,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm
         $useThrottle = $this->useThrottle;
 
         if ($useThrottle) {
-            $throttle = $this->findThrottleByLogin($credentials[$loginName], $this->ipAddress);
+            $throttle = $this->findThrottleByLogin($credentials[$loginName], $this->resolveIpAddress());
             $throttle->check();
         }
 
@@ -569,7 +574,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm
 
         // Check if the user has been throttled
         if ($this->useThrottle) {
-            $throttle = $this->findThrottleByUserId($user->getKey(), $this->ipAddress);
+            $throttle = $this->findThrottleByUserId($user->getKey(), $this->resolveIpAddress());
 
             if ($throttle->is_banned || $throttle->checkSuspended()) {
                 $this->logout();
@@ -658,10 +663,28 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm
         $this->viaRemember = false;
 
         /*
-         * Captured from the request in the constructor, so a worker that booted from the CLI would
-         * otherwise attribute every throttle record to the synthetic boot request's address.
+         * Deliberately unresolved rather than recaptured. The reset runs at the operation
+         * boundary, before the trusted-proxy middleware has run against the incoming request, so
+         * Request::ip() here would record the proxy's address — and, worse, may still be reading
+         * the previous operation's request. resolveIpAddress() derives it on first use instead,
+         * which under throttling happens mid-request, after the proxy chain is trusted.
          */
-        $this->ipAddress = Request::ip() ?? '0.0.0.0';
+        $this->ipAddress = null;
+    }
+
+    /**
+     * Returns the client IP for this operation, deriving it on first use.
+     *
+     * init() captures an address eagerly, which is correct under PHP-FPM where the manager is
+     * constructed mid-request. Under a persistent application server resetWorkerState() clears
+     * that eager capture at every operation boundary, and this method re-derives the address the
+     * first time something — throttling, in practice — actually needs it.
+     *
+     * @return string
+     */
+    protected function resolveIpAddress(): string
+    {
+        return $this->ipAddress ??= (Request::ip() ?? '0.0.0.0');
     }
 
     /**

--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -72,12 +72,12 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm
     /**
      * @var string|null The IP address of this request, or null when it has not been resolved yet.
      *
-     * Read through getIpAddress(). Under a persistent application server the value
-     * is deliberately left unresolved at the operation boundary and derived on first use, because
-     * the boundary runs before the trusted-proxy middleware has told the request which addresses
-     * to believe — an eager capture there records the load balancer instead of the client.
+     * Read through getIpAddress(). The value is deliberately left unresolved until first use:
+     * both singleton construction and the worker-boundary reset can run before the trusted-proxy
+     * middleware has told the request which addresses to believe, and an eager capture at either
+     * point records the load balancer instead of the client.
      */
-    public $ipAddress = '0.0.0.0';
+    public $ipAddress = null;
 
     /**
      * Session manager instance.
@@ -89,7 +89,16 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm
      */
     protected function init()
     {
-        $this->ipAddress = Request::ip();
+        /*
+         * Deliberately unresolved. The singleton can be constructed before the trusted-proxy
+         * middleware has run — during provider boot, or from anything that touches auth early —
+         * and an eager Request::ip() there records the load balancer's address and keeps it for
+         * the whole request, because getIpAddress() only derives when nothing is stored yet.
+         * Leaving it unresolved means the address is derived at first actual use, which under
+         * throttling happens mid-request, after the proxy chain is trusted. This holds under
+         * PHP-FPM and a persistent application server alike.
+         */
+        $this->ipAddress = null;
         $this->sessionManager = App::make(SessionManager::class);
     }
 

--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -72,7 +72,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm
     /**
      * @var string|null The IP address of this request, or null when it has not been resolved yet.
      *
-     * Read through resolveIpAddress() internally. Under a persistent application server the value
+     * Read through getIpAddress(). Under a persistent application server the value
      * is deliberately left unresolved at the operation boundary and derived on first use, because
      * the boundary runs before the trusted-proxy middleware has told the request which addresses
      * to believe — an eager capture there records the load balancer instead of the client.
@@ -437,7 +437,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm
         $useThrottle = $this->useThrottle;
 
         if ($useThrottle) {
-            $throttle = $this->findThrottleByLogin($credentials[$loginName], $this->resolveIpAddress());
+            $throttle = $this->findThrottleByLogin($credentials[$loginName], $this->getIpAddress());
             $throttle->check();
         }
 
@@ -574,7 +574,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm
 
         // Check if the user has been throttled
         if ($this->useThrottle) {
-            $throttle = $this->findThrottleByUserId($user->getKey(), $this->resolveIpAddress());
+            $throttle = $this->findThrottleByUserId($user->getKey(), $this->getIpAddress());
 
             if ($throttle->is_banned || $throttle->checkSuspended()) {
                 $this->logout();
@@ -666,7 +666,7 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm
          * Deliberately unresolved rather than recaptured. The reset runs at the operation
          * boundary, before the trusted-proxy middleware has run against the incoming request, so
          * Request::ip() here would record the proxy's address — and, worse, may still be reading
-         * the previous operation's request. resolveIpAddress() derives it on first use instead,
+         * the previous operation's request. getIpAddress() derives it on first use instead,
          * which under throttling happens mid-request, after the proxy chain is trusted.
          */
         $this->ipAddress = null;
@@ -680,11 +680,17 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm
      * that eager capture at every operation boundary, and this method re-derives the address the
      * first time something — throttling, in practice — actually needs it.
      *
-     * @return string
+     * A null return is meaningful and is deliberately NOT coalesced to a placeholder address.
+     * Request::ip() is null in console contexts (queue workers, artisan), and throttle lookups
+     * treat a null address as "match on the user alone" — which is how an existing ban is found
+     * from a console context. A placeholder like '0.0.0.0' would scope those lookups to an
+     * address no real record carries, missing the ban and minting spurious throttle rows.
+     *
+     * @return string|null
      */
-    protected function resolveIpAddress(): string
+    public function getIpAddress(): ?string
     {
-        return $this->ipAddress ??= (Request::ip() ?? '0.0.0.0');
+        return $this->ipAddress ??= Request::ip();
     }
 
     /**

--- a/src/Auth/Manager.php
+++ b/src/Auth/Manager.php
@@ -10,7 +10,7 @@ use Illuminate\Session\SessionManager;
 /**
  * Authentication manager
  */
-class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
+class Manager implements \Illuminate\Contracts\Auth\StatefulGuard, \Winter\Storm\Contracts\ResetsWorkerState
 {
     use \Winter\Storm\Support\Traits\Singleton;
 
@@ -622,13 +622,46 @@ class Manager implements \Illuminate\Contracts\Auth\StatefulGuard
      */
     public function once(array $credentials = [])
     {
+        $previousUseSession = $this->useSession;
+
         $this->useSession = false;
 
-        $user = $this->authenticate($credentials);
-
-        $this->useSession = true;
+        try {
+            $user = $this->authenticate($credentials);
+        }
+        finally {
+            /*
+             * Restore the previous value even when authentication throws. This manager is a
+             * singleton, so leaving it false would silently disable session persistence for every
+             * later caller in the process. The previous value is restored rather than a hard true
+             * because subclasses configure their own default.
+             */
+            $this->useSession = $previousUseSession;
+        }
 
         return !!$user;
+    }
+
+    /**
+     * Discard the authentication state derived from the previous operation.
+     *
+     * Everything cleared here is request-derived: the resolved user, any impersonation, throttle
+     * models keyed by user and IP, the remembered-login flag, and the client address captured at
+     * construction. Configuration such as the model classes, session key and throttle settings is
+     * deliberately left alone, since it belongs to the worker rather than to a request.
+     */
+    public function resetWorkerState(): void
+    {
+        $this->user = null;
+        $this->impersonator = null;
+        $this->throttle = [];
+        $this->viaRemember = false;
+
+        /*
+         * Captured from the request in the constructor, so a worker that booted from the CLI would
+         * otherwise attribute every throttle record to the synthetic boot request's address.
+         */
+        $this->ipAddress = Request::ip() ?? '0.0.0.0';
     }
 
     /**

--- a/src/Contracts/ResetsWorkerState.php
+++ b/src/Contracts/ResetsWorkerState.php
@@ -1,0 +1,30 @@
+<?php namespace Winter\Storm\Contracts;
+
+/**
+ * Implemented by services that retain state derived from a single operation.
+ *
+ * Under PHP-FPM every request gets a fresh process, so request-scoped state on a long-lived
+ * object is harmless. Under a persistent application server such as Laravel Octane the same
+ * object serves many requests, and anything derived from one request stays visible to the next.
+ *
+ * Winter invokes this at the start of every operation, after clearing core state and before the
+ * request is dispatched. Plugins that cache per-request data on a plugin object, a singleton or a
+ * static property should implement it.
+ *
+ * Two rules keep implementations safe:
+ *
+ * - **Be idempotent.** It may be called more than once for a single operation, including after an
+ *   operation that threw partway through.
+ * - **Do not unregister boot-time extensions.** Registration callbacks, aliases, navigation
+ *   definitions and event listeners are built once per worker; discarding them leaves the worker
+ *   permanently degraded. Clear only what a request produced.
+ *
+ * @author Winter CMS
+ */
+interface ResetsWorkerState
+{
+    /**
+     * Discard state derived from the previous operation.
+     */
+    public function resetWorkerState(): void;
+}

--- a/src/Events/Dispatcher.php
+++ b/src/Events/Dispatcher.php
@@ -213,6 +213,41 @@ class Dispatcher extends BaseDispatcher
     }
 
     /**
+     * Add the listeners for the event's interfaces to the given array.
+     *
+     * Laravel's implementation cannot be inherited here because the two dispatchers store
+     * listeners differently. Laravel keeps raw listeners as `listeners[event][]` and wraps them
+     * later in `prepareListeners()`; this dispatcher wraps them in `listen()` and keys them by
+     * priority as `listeners[event][priority][]`. Reusing the parent implementation therefore
+     * hands each priority bucket to `makeListener()` as though the bucket itself were a listener,
+     * which produces an invalid array callable and throws when the event is dispatched.
+     *
+     * Any event registered against an interface is affected. Laravel Octane relies on exactly
+     * that: it registers its post-operation cleanup against the OperationTerminated contract, so
+     * without this override every RequestTerminated dispatch fails.
+     *
+     * @param string $eventName
+     * @param array $listeners
+     * @return array
+     */
+    protected function addInterfaceListeners($eventName, array $listeners = [])
+    {
+        foreach (class_implements($eventName) as $interface) {
+            if (!isset($this->listeners[$interface])) {
+                continue;
+            }
+
+            if (!isset($this->sorted[$interface])) {
+                $this->sortListeners($interface);
+            }
+
+            $listeners = array_merge($listeners, $this->sorted[$interface]);
+        }
+
+        return $listeners;
+    }
+
+    /**
      * Sort the listeners for a given event by priority.
      *
      * @param string $eventName

--- a/src/Exception/ErrorHandler.php
+++ b/src/Exception/ErrorHandler.php
@@ -102,6 +102,22 @@ class ErrorHandler
     }
 
     /**
+     * Discards every applied mask.
+     *
+     * applyMask() and removeMask() are expected to be balanced, but an exception thrown between
+     * them leaves a mask applied. In a single-request process that is harmless because the process
+     * ends; under a persistent application server the stale mask would be applied to the next
+     * request's exception, and $maskLayers would keep growing with every unbalanced pair.
+     *
+     * @return void
+     */
+    public static function resetMaskState()
+    {
+        static::$activeMask = null;
+        static::$maskLayers = [];
+    }
+
+    /**
      * Returns a more descriptive error message if application
      * debug mode is turned on.
      * @param Throwable $exception

--- a/src/Extension/ExtendableTrait.php
+++ b/src/Extension/ExtendableTrait.php
@@ -507,10 +507,22 @@ trait ExtendableTrait
             $extension = self::$extendableStaticMethods[$className][$name];
 
             if (method_exists($extension, $name) && is_callable([$extension, $name])) {
+                $previousCalledClass = $extension::$extendableStaticCalledClass;
+
                 $extension::$extendableStaticCalledClass = $className;
-                $result = forward_static_call_array(array($extension, $name), $params);
-                $extension::$extendableStaticCalledClass = null;
-                return $result;
+
+                try {
+                    return forward_static_call_array(array($extension, $name), $params);
+                }
+                finally {
+                    /*
+                     * Clear the called class even when the extension throws. The property is
+                     * static, so a thrown call would otherwise leave the previous caller's class
+                     * name visible to every later static call in the process, including calls made
+                     * while handling a subsequent request.
+                     */
+                    $extension::$extendableStaticCalledClass = $previousCalledClass;
+                }
             }
         }
 

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -356,14 +356,17 @@ class Application extends ApplicationBase
     /**
      * Determine if a persistent application server is serving requests from this process.
      *
-     * Distinct from runningInConsole(), which is true under an application server as well, because
-     * the worker is started from the CLI. Anything that must tell "a worker serving HTTP" apart from
-     * "an artisan command" has to ask this instead.
+     * Distinct from runningInConsole(). Octane's worker entrypoints set APP_RUNNING_IN_CONSOLE to
+     * false before creating the application, so inside a worker runningInConsole() answers false —
+     * but that only distinguishes a worker from an artisan command, not from an ordinary PHP-FPM
+     * request. Anything that must tell "a persistent worker" apart from both has to ask this
+     * instead.
      *
-     * The reason it matters at boot is that a worker's providers register once, from a CLI context,
-     * and then serve requests of every kind. A registration gated on a per-request condition —
-     * runningInBackend() being the significant one — is therefore decided by the synthetic boot
-     * request and never revisited, so it never happens at all. Such a gate has to admit a worker.
+     * The reason it matters at boot is that a worker's providers register once, against a
+     * synthetic request rather than a real one, and then serve requests of every kind. A
+     * registration gated on a per-request condition — runningInBackend() being the significant
+     * one — is therefore decided by that synthetic boot request and never revisited, so it never
+     * happens at all. Such a gate has to admit a worker.
      *
      * The client contract is the signal because Octane binds it in the worker process only; the
      * package merely being installed does not bind it, so an artisan command still answers false.

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -354,6 +354,28 @@ class Application extends ApplicationBase
     }
 
     /**
+     * Determine if a persistent application server is serving requests from this process.
+     *
+     * Distinct from runningInConsole(), which is true under an application server as well, because
+     * the worker is started from the CLI. Anything that must tell "a worker serving HTTP" apart from
+     * "an artisan command" has to ask this instead.
+     *
+     * The reason it matters at boot is that a worker's providers register once, from a CLI context,
+     * and then serve requests of every kind. A registration gated on a per-request condition —
+     * runningInBackend() being the significant one — is therefore decided by the synthetic boot
+     * request and never revisited, so it never happens at all. Such a gate has to admit a worker.
+     *
+     * The client contract is the signal because Octane binds it in the worker process only; the
+     * package merely being installed does not bind it, so an artisan command still answers false.
+     *
+     * @return bool
+     */
+    public function runningInApplicationServer(): bool
+    {
+        return $this->bound('Laravel\Octane\Contracts\Client');
+    }
+
+    /**
      * Returns true if a database connection is present.
      */
     public function hasDatabase(): bool

--- a/src/Foundation/Bootstrap/RegisterWinter.php
+++ b/src/Foundation/Bootstrap/RegisterWinter.php
@@ -13,9 +13,20 @@ class RegisterWinter
     public function bootstrap(Application $app): void
     {
         /*
-         * Workaround for CLI and URL based in subdirectory
+         * Workaround for CLI and URL based in subdirectory.
+         *
+         * The request must already be bound: resolving the URL generator without one throws,
+         * because Illuminate\Routing\UrlGenerator requires a request instance. The console
+         * kernel guarantees this by running SetRequestForConsole before this bootstrapper, and
+         * HTTP requests never reach this branch because they are not running in console.
+         *
+         * An application server that boots from the CLI and then serves HTTP requests, such as
+         * Laravel Octane, satisfies runningInConsole() while bootstrapping through the HTTP
+         * kernel, which has no SetRequestForConsole. Skipping the workaround there is also
+         * correct on its own terms: each served request supplies its own root URL, so forcing
+         * the configured one would pin every generated URL to app.url for the worker's life.
          */
-        if ($app->runningInConsole()) {
+        if ($app->runningInConsole() && $app->bound('request')) {
             $app['url']->forceRootUrl($app['config']->get('app.url'));
         }
 

--- a/src/Halcyon/MemoryCacheManager.php
+++ b/src/Halcyon/MemoryCacheManager.php
@@ -16,9 +16,48 @@ class MemoryCacheManager extends CacheManager
     {
         $disabled = Config::get('cache.disableRequestCache', null);
         if ($disabled === null) {
-            return !App::runningInConsole();
+            return !App::runningInConsole() || static::runningInApplicationServer();
         }
 
         return !$disabled;
+    }
+
+    /**
+     * Determine whether a persistent application server is handling HTTP requests.
+     *
+     * runningInConsole() only reports the SAPI, so it cannot tell a console command apart from an
+     * application server such as Laravel Octane, which boots from the CLI and then serves HTTP.
+     * Without this check the request cache silently stays disabled under exactly the runtime that
+     * was adopted for throughput.
+     *
+     * Octane binds its client contract into the base container when the worker boots, which is the
+     * cheapest reliable signal and is absent from ordinary console commands.
+     *
+     * @return bool
+     */
+    protected static function runningInApplicationServer()
+    {
+        $app = App::getFacadeRoot();
+
+        return $app instanceof \Winter\Storm\Foundation\Application
+            ? $app->runningInApplicationServer()
+            : App::bound('Laravel\Octane\Contracts\Client');
+    }
+
+    /**
+     * Discard cached records belonging to the previous operation.
+     *
+     * Only the in-memory request cache is cleared. External cache stores keep their own
+     * invalidation rules, so flush() is deliberately not used here.
+     *
+     * @return void
+     */
+    public function flushRequestCache()
+    {
+        foreach ($this->stores as $store) {
+            if ($store instanceof MemoryRepository) {
+                $store->flushInternalCache();
+            }
+        }
     }
 }

--- a/src/Halcyon/Model.php
+++ b/src/Halcyon/Model.php
@@ -1543,6 +1543,30 @@ class Model extends Extendable implements ModelInterface, ArrayAccess, Arrayable
     }
 
     /**
+     * Discard the request-level record cache without touching external cache stores.
+     *
+     * The cache manager is held statically and so outlives a single operation on a persistent
+     * application server. Its in-memory repository is request-scoped by design, so it must be
+     * emptied at each operation boundary; the external stores it wraps keep their own invalidation
+     * rules and are deliberately left alone.
+     *
+     * Not the same as flushDuplicateCache() below, which is deliberately left as it is because it has
+     * existing callers. That one empties only the default driver and returns early when
+     * MemoryCacheManager::isEnabled() is false; this one empties every store the manager has resolved
+     * and is unconditional. Use this at an operation boundary, where missing a non-default store would
+     * carry one operation's records into the next, and that one where the intent is to invalidate the
+     * cache the current code path is reading through.
+     *
+     * @return void
+     */
+    public static function flushRequestCache()
+    {
+        if (static::$cache instanceof MemoryCacheManager) {
+            static::$cache->flushRequestCache();
+        }
+    }
+
+    /**
      * Initializes the object properties from the cached data. The extra data
      * set here becomes available as attributes set on the model after fetch.
      *

--- a/tests/Events/InterfaceListenerTest.php
+++ b/tests/Events/InterfaceListenerTest.php
@@ -1,0 +1,110 @@
+<?php namespace Events;
+
+use Winter\Storm\Events\Dispatcher;
+
+/**
+ * Listeners registered against an interface must fire for every event implementing it.
+ *
+ * This dispatcher wraps listeners in listen() and keys them by priority, so it cannot reuse
+ * Laravel's addInterfaceListeners(), which expects raw listeners stored one level flatter.
+ * Doing so hands each priority bucket to makeListener() as if the bucket were itself a
+ * listener, and dispatching then throws on the resulting invalid array callable.
+ */
+class InterfaceListenerTest extends \Winter\Storm\Tests\TestCase
+{
+    public function testListenerRegisteredOnAnInterfaceReceivesTheImplementingEvent()
+    {
+        $received = [];
+
+        $dispatcher = new Dispatcher();
+        $dispatcher->listen(InterfaceListenerTestContract::class, function ($event) use (&$received) {
+            $received[] = get_class($event);
+        });
+
+        $dispatcher->dispatch(new InterfaceListenerTestEvent('payload'));
+
+        $this->assertSame([InterfaceListenerTestEvent::class], $received);
+    }
+
+    public function testInterfaceAndClassListenersBothFireInPriorityOrder()
+    {
+        $order = [];
+
+        $dispatcher = new Dispatcher();
+        $dispatcher->listen(InterfaceListenerTestEvent::class, function () use (&$order) {
+            $order[] = 'class-default';
+        });
+        $dispatcher->listen(InterfaceListenerTestEvent::class, function () use (&$order) {
+            $order[] = 'class-high';
+        }, 10);
+        $dispatcher->listen(InterfaceListenerTestContract::class, function () use (&$order) {
+            $order[] = 'interface';
+        });
+
+        $dispatcher->dispatch(new InterfaceListenerTestEvent('payload'));
+
+        // Class listeners sort by descending priority; interface listeners are appended after.
+        $this->assertSame(['class-high', 'class-default', 'interface'], $order);
+    }
+
+    public function testGetListenersIncludesInterfaceListenersOnce()
+    {
+        $dispatcher = new Dispatcher();
+        $dispatcher->listen(InterfaceListenerTestContract::class, fn () => null);
+        $dispatcher->listen(InterfaceListenerTestEvent::class, fn () => null);
+
+        $this->assertCount(2, $dispatcher->getListeners(InterfaceListenerTestEvent::class));
+        $this->assertCount(1, $dispatcher->getListeners(InterfaceListenerTestContract::class));
+    }
+
+    public function testAnEventWithNoInterfaceListenersStillDispatches()
+    {
+        $hit = false;
+
+        $dispatcher = new Dispatcher();
+        $dispatcher->listen(InterfaceListenerTestEvent::class, function () use (&$hit) {
+            $hit = true;
+        });
+
+        $dispatcher->dispatch(new InterfaceListenerTestEvent('payload'));
+
+        $this->assertTrue($hit);
+    }
+
+    /**
+     * Class-string listeners are how Laravel Octane registers its post-operation cleanup against
+     * the OperationTerminated contract, so they must resolve through the container as well.
+     */
+    public function testClassStringListenerRegisteredOnAnInterfaceIsResolved()
+    {
+        InterfaceListenerTestHandler::$calls = [];
+
+        $dispatcher = new Dispatcher();
+        $dispatcher->listen(InterfaceListenerTestContract::class, InterfaceListenerTestHandler::class);
+
+        $dispatcher->dispatch(new InterfaceListenerTestEvent('from-contract'));
+
+        $this->assertSame(['from-contract'], InterfaceListenerTestHandler::$calls);
+    }
+}
+
+interface InterfaceListenerTestContract
+{
+}
+
+class InterfaceListenerTestEvent implements InterfaceListenerTestContract
+{
+    public function __construct(public string $value)
+    {
+    }
+}
+
+class InterfaceListenerTestHandler
+{
+    public static array $calls = [];
+
+    public function handle(InterfaceListenerTestEvent $event): void
+    {
+        static::$calls[] = $event->value;
+    }
+}

--- a/tests/Foundation/ApplicationServerDetectionTest.php
+++ b/tests/Foundation/ApplicationServerDetectionTest.php
@@ -7,19 +7,11 @@ use Winter\Storm\Foundation\Application;
 use Winter\Storm\Tests\TestCase;
 
 /**
- * A worker's providers register once, from a CLI context, and then serve requests of every kind.
+ * runningInApplicationServer() gates boot-time registrations that per-request checks would skip
+ * during a worker's boot. runningInConsole() cannot stand in for it: that only separates a worker
+ * from an artisan command, not from an ordinary request.
  *
- * Anything gated on a per-request condition at registration time is therefore decided by the synthetic
- * boot request and never revisited. runningInBackend() is the case that matters: it is false during a
- * worker's boot, so the back-end registrations behind it never ran at all, and any back-end page
- * needing a form widget failed. Winter's module providers now also admit an application server, which
- * makes this detection load-bearing.
- *
- * runningInConsole() cannot serve the purpose, because a worker is started from the CLI and so answers
- * true — which is precisely why this is a separate method.
- *
- * The binding is referenced by name rather than by importing the interface: Storm does not depend on
- * laravel/octane, and must not start doing so for a test.
+ * The Octane binding is referenced by name because Storm does not depend on laravel/octane.
  */
 class ApplicationServerDetectionTest extends TestCase
 {
@@ -36,8 +28,8 @@ class ApplicationServerDetectionTest extends TestCase
     }
 
     /**
-     * Octane binds the client contract in the worker process only, so the package merely being
-     * installed must not be enough — otherwise every artisan command would be treated as a worker.
+     * Octane binds the client contract in worker processes only. Installing the package must not
+     * be enough, or every artisan command would count as a worker.
      */
     public function testDetectionIsDrivenByTheBindingRatherThanThePackage()
     {
@@ -54,8 +46,8 @@ class ApplicationServerDetectionTest extends TestCase
     }
 
     /**
-     * The distinction the method exists for: a worker is a console process too, so the two answers
-     * have to be able to disagree.
+     * The two answers must be independent: a process can report a console context and still be
+     * serving requests.
      */
     public function testAnApplicationServerIsDetectedEvenThoughItIsAlsoAConsoleProcess()
     {
@@ -70,16 +62,12 @@ class ApplicationServerDetectionTest extends TestCase
     }
 
     /**
-     * The global trans() helper Storm defines must not return an object for a null key.
+     * trans(null) must not return the translator object: e(trans($key)) becomes a TypeError when
+     * it does, which broke back-end pages under a worker entry point that loaded Composer's
+     * autoloader (and its Laravel helpers) first.
      *
-     * Laravel's helper returns the translator instance in that case, and e() then raises a TypeError
-     * on it — which is what broke every back-end page with a settings menu when a worker entry point
-     * loaded Composer's autoloader before bootstrap/autoload.php and so got Laravel's definition.
-     *
-     * Asserted against Storm's Translator rather than the global helper on purpose: vendor/bin/phpunit
-     * requires Composer's autoloader before the suite's bootstrap file, so inside the test suite the
-     * global helpers are always Laravel's regardless of which entry point production uses. The
-     * behaviour that has to hold is this method's.
+     * Asserted against Storm's Translator directly because the test suite always gets Laravel's
+     * global helpers, regardless of which entry point production uses.
      */
     public function testTranslatingANullKeyDoesNotReturnAnObject()
     {

--- a/tests/Foundation/ApplicationServerDetectionTest.php
+++ b/tests/Foundation/ApplicationServerDetectionTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Winter\Storm\Tests\Foundation;
+
+use stdClass;
+use Winter\Storm\Foundation\Application;
+use Winter\Storm\Tests\TestCase;
+
+/**
+ * A worker's providers register once, from a CLI context, and then serve requests of every kind.
+ *
+ * Anything gated on a per-request condition at registration time is therefore decided by the synthetic
+ * boot request and never revisited. runningInBackend() is the case that matters: it is false during a
+ * worker's boot, so the back-end registrations behind it never ran at all, and any back-end page
+ * needing a form widget failed. Winter's module providers now also admit an application server, which
+ * makes this detection load-bearing.
+ *
+ * runningInConsole() cannot serve the purpose, because a worker is started from the CLI and so answers
+ * true — which is precisely why this is a separate method.
+ *
+ * The binding is referenced by name rather than by importing the interface: Storm does not depend on
+ * laravel/octane, and must not start doing so for a test.
+ */
+class ApplicationServerDetectionTest extends TestCase
+{
+    protected const OCTANE_CLIENT = 'Laravel\Octane\Contracts\Client';
+
+    protected function makeApplication(): Application
+    {
+        return new Application(__DIR__);
+    }
+
+    public function testAPlainApplicationIsNotAnApplicationServer()
+    {
+        $this->assertFalse($this->makeApplication()->runningInApplicationServer());
+    }
+
+    /**
+     * Octane binds the client contract in the worker process only, so the package merely being
+     * installed must not be enough — otherwise every artisan command would be treated as a worker.
+     */
+    public function testDetectionIsDrivenByTheBindingRatherThanThePackage()
+    {
+        $app = $this->makeApplication();
+
+        $this->assertFalse(
+            $app->runningInApplicationServer(),
+            'Nothing is bound yet, so this must be false whether or not laravel/octane is installed.'
+        );
+
+        $app->instance(static::OCTANE_CLIENT, new stdClass());
+
+        $this->assertTrue($app->runningInApplicationServer());
+    }
+
+    /**
+     * The distinction the method exists for: a worker is a console process too, so the two answers
+     * have to be able to disagree.
+     */
+    public function testAnApplicationServerIsDetectedEvenThoughItIsAlsoAConsoleProcess()
+    {
+        $app = $this->makeApplication();
+        $app->instance(static::OCTANE_CLIENT, new stdClass());
+
+        $this->assertTrue($app->runningInConsole(), 'The test suite itself runs in the console.');
+        $this->assertTrue(
+            $app->runningInApplicationServer(),
+            'A worker is started from the CLI, so this must not be derived from the console answer.'
+        );
+    }
+
+    /**
+     * The global trans() helper Storm defines must not return an object for a null key.
+     *
+     * Laravel's helper returns the translator instance in that case, and e() then raises a TypeError
+     * on it — which is what broke every back-end page with a settings menu when a worker entry point
+     * loaded Composer's autoloader before bootstrap/autoload.php and so got Laravel's definition.
+     *
+     * Asserted against Storm's Translator rather than the global helper on purpose: vendor/bin/phpunit
+     * requires Composer's autoloader before the suite's bootstrap file, so inside the test suite the
+     * global helpers are always Laravel's regardless of which entry point production uses. The
+     * behaviour that has to hold is this method's.
+     */
+    public function testTranslatingANullKeyDoesNotReturnAnObject()
+    {
+        $translator = new \Winter\Storm\Translation\Translator(
+            new \Winter\Storm\Translation\FileLoader(
+                new \Winter\Storm\Filesystem\Filesystem(),
+                __DIR__
+            ),
+            'en'
+        );
+
+        $translated = $translator->trans(null);
+
+        $this->assertNotInstanceOf(
+            \Winter\Storm\Translation\Translator::class,
+            $translated,
+            'Returning the translator itself makes e(trans($value)) a TypeError for any null value.'
+        );
+        $this->assertTrue(
+            $translated === null || is_string($translated) || is_array($translated),
+            'trans() must yield something e() can escape.'
+        );
+    }
+}

--- a/tests/Foundation/Bootstrap/RegisterWinterTest.php
+++ b/tests/Foundation/Bootstrap/RegisterWinterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Winter\Storm\Tests\Foundation\Bootstrap;
+
+use Illuminate\Config\Repository;
+use Illuminate\Http\Request;
+use Winter\Storm\Foundation\Application;
+use Winter\Storm\Foundation\Bootstrap\RegisterWinter;
+
+/**
+ * RegisterWinter forces the configured root URL when running in console, because a console
+ * process has no request to derive one from.
+ *
+ * The workaround needs the request to be bound already: resolving the URL generator without one
+ * throws, since Illuminate\Routing\UrlGenerator requires a request instance. Both stock kernels
+ * satisfy that — the console kernel runs SetRequestForConsole first, and HTTP requests are not
+ * running in console — but an application server that boots from the CLI and then serves HTTP,
+ * such as Laravel Octane, bootstraps through the HTTP kernel while runningInConsole() is true and
+ * has no request bound at that point.
+ */
+class RegisterWinterTest extends \Winter\Storm\Tests\TestCase
+{
+    /**
+     * A bare application, which registers Storm's routing provider (and therefore the real `url`
+     * binding) but has performed no HTTP bootstrapping.
+     */
+    protected function makeApplication(): Application
+    {
+        $app = new Application(__DIR__);
+
+        $app->instance('config', new Repository([
+            'app' => ['url' => 'https://configured.example', 'asset_url' => null],
+            'cms' => [],
+        ]));
+
+        return $app;
+    }
+
+    /**
+     * The regression: bootstrapping in console with no request bound must not throw.
+     */
+    public function testBootstrappingInConsoleWithoutARequestDoesNotThrow()
+    {
+        $app = $this->makeApplication();
+
+        $this->assertTrue($app->runningInConsole());
+        $this->assertFalse($app->bound('request'));
+
+        (new RegisterWinter())->bootstrap($app);
+
+        $this->assertTrue($app->bound('string'));
+        $this->assertTrue($app->bound('svg'));
+    }
+
+    /**
+     * Skipping the workaround is also correct on its own terms: each served request supplies its
+     * own root URL, so the configured one must not be pinned for the worker's lifetime.
+     */
+    public function testTheConfiguredRootUrlIsNotForcedWhenNoRequestIsBound()
+    {
+        $app = $this->makeApplication();
+
+        (new RegisterWinter())->bootstrap($app);
+
+        $app->instance('request', Request::create('https://served.example/some/page', 'GET'));
+
+        $this->assertStringStartsWith('https://served.example', $app['url']->to('/other'));
+    }
+
+    /**
+     * Existing console behaviour is preserved when a request has already been bound, which is
+     * what the console kernel guarantees via SetRequestForConsole.
+     */
+    public function testTheConfiguredRootUrlIsStillForcedWhenARequestIsBound()
+    {
+        $app = $this->makeApplication();
+        $app->instance('request', Request::create('http://localhost/artisan', 'GET'));
+
+        (new RegisterWinter())->bootstrap($app);
+
+        /*
+         * forceRootUrl() overrides the host but leaves the scheme to the request, so assert on the
+         * forced host rather than the full URL.
+         */
+        $url = $app['url']->to('/other');
+
+        $this->assertStringContainsString('configured.example', $url);
+        $this->assertStringNotContainsString('localhost', $url);
+    }
+
+    /**
+     * The rest of the bootstrapper must run regardless of the URL workaround.
+     */
+    public function testConfiguredPathsAreStillApplied()
+    {
+        $app = $this->makeApplication();
+        $app['config']->set('cms.pluginsPathLocal', '/tmp/register-winter-plugins');
+        $app['config']->set('cms.themesPathLocal', '/tmp/register-winter-themes');
+
+        (new RegisterWinter())->bootstrap($app);
+
+        $this->assertStringContainsString('register-winter-plugins', $app->pluginsPath());
+        $this->assertStringContainsString('register-winter-themes', $app->themesPath());
+    }
+}

--- a/tests/Foundation/Bootstrap/RegisterWinterTest.php
+++ b/tests/Foundation/Bootstrap/RegisterWinterTest.php
@@ -8,15 +8,10 @@ use Winter\Storm\Foundation\Application;
 use Winter\Storm\Foundation\Bootstrap\RegisterWinter;
 
 /**
- * RegisterWinter forces the configured root URL when running in console, because a console
- * process has no request to derive one from.
- *
- * The workaround needs the request to be bound already: resolving the URL generator without one
- * throws, since Illuminate\Routing\UrlGenerator requires a request instance. Both stock kernels
- * satisfy that — the console kernel runs SetRequestForConsole first, and HTTP requests are not
- * running in console — but an application server that boots from the CLI and then serves HTTP,
- * such as Laravel Octane, bootstraps through the HTTP kernel while runningInConsole() is true and
- * has no request bound at that point.
+ * RegisterWinter forces the configured root URL when no request is bound to derive one from.
+ * The gate must be the request itself, not runningInConsole(): a worker boots through the HTTP
+ * kernel before any request exists, and the override must not fire against the requests it
+ * serves afterwards.
  */
 class RegisterWinterTest extends \Winter\Storm\Tests\TestCase
 {

--- a/tests/Foundation/WorkerStateTest.php
+++ b/tests/Foundation/WorkerStateTest.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Winter\Storm\Tests\Foundation;
+
+use Illuminate\Http\Request;
+use ReflectionObject;
+use RuntimeException;
+use Winter\Storm\Auth\Manager as AuthManager;
+use Winter\Storm\Contracts\ResetsWorkerState;
+use Winter\Storm\Exception\ErrorHandler;
+use Winter\Storm\Halcyon\MemoryCacheManager;
+
+/**
+ * State that a single operation produces must not survive into the next one.
+ *
+ * Under PHP-FPM each request gets a fresh process, so these are all harmless. Under a persistent
+ * application server the same objects and static properties serve every request, and anything
+ * derived from one request stays visible to the next.
+ */
+class WorkerStateTest extends \Winter\Storm\Tests\TestCase
+{
+    protected function setProtected(object $target, string $property, $value): void
+    {
+        $prop = (new ReflectionObject($target))->getProperty($property);
+        $prop->setAccessible(true);
+        $prop->setValue($target, $value);
+    }
+
+    protected function getProtected(object $target, string $property)
+    {
+        $prop = (new ReflectionObject($target))->getProperty($property);
+        $prop->setAccessible(true);
+
+        return $prop->getValue($target);
+    }
+
+    //
+    // Auth manager
+    //
+
+    public function testAuthManagerImplementsTheResetContract()
+    {
+        $this->assertInstanceOf(ResetsWorkerState::class, AuthManager::instance());
+    }
+
+    public function testResettingTheAuthManagerClearsRequestDerivedState()
+    {
+        $manager = AuthManager::instance();
+
+        $this->setProtected($manager, 'user', new \stdClass());
+        $this->setProtected($manager, 'impersonator', new \stdClass());
+        $this->setProtected($manager, 'throttle', ['abc' => new \stdClass()]);
+        $this->setProtected($manager, 'viaRemember', true);
+        $manager->ipAddress = '203.0.113.9';
+
+        $manager->resetWorkerState();
+
+        $this->assertNull($this->getProtected($manager, 'user'), 'the resolved user must not persist');
+        $this->assertNull($this->getProtected($manager, 'impersonator'), 'impersonation must not persist');
+        $this->assertSame([], $this->getProtected($manager, 'throttle'));
+        $this->assertFalse($this->getProtected($manager, 'viaRemember'));
+        $this->assertNotSame('203.0.113.9', $manager->ipAddress);
+    }
+
+    /**
+     * Configuration belongs to the worker, not to a request, so it must survive a reset.
+     */
+    public function testResettingTheAuthManagerPreservesConfiguration()
+    {
+        $manager = AuthManager::instance();
+
+        $userModel = $this->getProtected($manager, 'userModel');
+        $sessionKey = $this->getProtected($manager, 'sessionKey');
+        $useThrottle = $this->getProtected($manager, 'useThrottle');
+
+        $manager->resetWorkerState();
+
+        $this->assertSame($userModel, $this->getProtected($manager, 'userModel'));
+        $this->assertSame($sessionKey, $this->getProtected($manager, 'sessionKey'));
+        $this->assertSame($useThrottle, $this->getProtected($manager, 'useThrottle'));
+    }
+
+    public function testResettingTheAuthManagerIsIdempotent()
+    {
+        $manager = AuthManager::instance();
+
+        $manager->resetWorkerState();
+        $manager->resetWorkerState();
+
+        $this->assertNull($this->getProtected($manager, 'user'));
+        $this->assertSame([], $this->getProtected($manager, 'throttle'));
+    }
+
+    /**
+     * once() disables session persistence for a single authentication attempt. A throw used to
+     * leave it disabled for every later caller in the process.
+     */
+    public function testOnceRestoresSessionUseWhenAuthenticationThrows()
+    {
+        $manager = WorkerStateThrowingAuthManager::instance();
+
+        $this->assertTrue($this->getProtected($manager, 'useSession'));
+
+        try {
+            $manager->once(['login' => 'someone', 'password' => 'secret']);
+            $this->fail('The throwing manager should have propagated its exception.');
+        }
+        catch (RuntimeException $ex) {
+            // Expected.
+        }
+
+        $this->assertTrue(
+            $this->getProtected($manager, 'useSession'),
+            'a thrown authentication attempt must not leave session use disabled'
+        );
+    }
+
+    public function testOnceRestoresTheConfiguredValueRatherThanHardCodingTrue()
+    {
+        WorkerStateThrowingAuthManager::forgetInstance();
+        $manager = WorkerStateThrowingAuthManager::instance();
+        $this->setProtected($manager, 'useSession', false);
+
+        try {
+            $manager->once(['login' => 'someone', 'password' => 'secret']);
+        }
+        catch (RuntimeException $ex) {
+            // Expected.
+        }
+
+        $this->assertFalse(
+            $this->getProtected($manager, 'useSession'),
+            'the previous value must be restored, not replaced with true'
+        );
+    }
+
+    //
+    // Error handler masks
+    //
+
+    public function testResettingMaskStateDiscardsUnbalancedMasks()
+    {
+        ErrorHandler::applyMask(new RuntimeException('first'));
+        ErrorHandler::applyMask(new RuntimeException('second'));
+
+        ErrorHandler::resetMaskState();
+
+        $activeMask = (new \ReflectionClass(ErrorHandler::class))->getProperty('activeMask');
+        $activeMask->setAccessible(true);
+        $maskLayers = (new \ReflectionClass(ErrorHandler::class))->getProperty('maskLayers');
+        $maskLayers->setAccessible(true);
+
+        $this->assertNull($activeMask->getValue());
+        $this->assertSame([], $maskLayers->getValue());
+    }
+
+    public function testResettingMaskStateIsIdempotent()
+    {
+        ErrorHandler::resetMaskState();
+        ErrorHandler::resetMaskState();
+
+        $activeMask = (new \ReflectionClass(ErrorHandler::class))->getProperty('activeMask');
+        $activeMask->setAccessible(true);
+
+        $this->assertNull($activeMask->getValue());
+    }
+
+    //
+    // Static extension dispatch
+    //
+
+    /**
+     * The called class is stored statically while a static extension method runs, so a throw used
+     * to leave the previous caller's class name visible to every later static call.
+     */
+    public function testStaticCalledClassIsClearedWhenAnExtensionThrows()
+    {
+        WorkerStateStaticExtension::$extendableStaticCalledClass = 'PreviousCaller';
+
+        try {
+            WorkerStateExtendableHost::explode();
+            $this->fail('The extension should have propagated its exception.');
+        }
+        catch (RuntimeException $ex) {
+            // Expected.
+        }
+
+        $this->assertSame(
+            'PreviousCaller',
+            WorkerStateStaticExtension::$extendableStaticCalledClass,
+            'a thrown static extension call must restore the previous called class'
+        );
+    }
+
+    //
+    // Halcyon request cache
+    //
+
+    /**
+     * runningInConsole() only reports the SAPI, so an application server that boots from the CLI
+     * and then serves HTTP would otherwise have the request cache silently disabled.
+     */
+    public function testRequestCacheIsEnabledForAnApplicationServerDespiteTheConsoleSapi()
+    {
+        $this->app['config']->set('cache.disableRequestCache', null);
+
+        $this->assertTrue($this->app->runningInConsole(), 'the test suite runs under the CLI SAPI');
+        $this->assertFalse(MemoryCacheManager::isEnabled());
+
+        $this->app->instance('Laravel\Octane\Contracts\Client', new \stdClass());
+
+        $this->assertTrue(
+            MemoryCacheManager::isEnabled(),
+            'a worker serving HTTP must get the request cache it was adopted for'
+        );
+
+        $this->app->forgetInstance('Laravel\Octane\Contracts\Client');
+    }
+
+    public function testAnExplicitDisableStillWins()
+    {
+        $this->app->instance('Laravel\Octane\Contracts\Client', new \stdClass());
+        $this->app['config']->set('cache.disableRequestCache', true);
+
+        $this->assertFalse(MemoryCacheManager::isEnabled());
+
+        $this->app['config']->set('cache.disableRequestCache', null);
+        $this->app->forgetInstance('Laravel\Octane\Contracts\Client');
+    }
+}
+
+/**
+ * An auth manager whose authentication always fails, standing in for invalid credentials or a
+ * failure inside a user model event.
+ */
+class WorkerStateThrowingAuthManager extends AuthManager
+{
+    public function authenticate(array $credentials, $remember = true)
+    {
+        throw new RuntimeException('authentication exploded');
+    }
+}
+
+class WorkerStateExtendableHost
+{
+    use \Winter\Storm\Extension\ExtendableTrait;
+
+    /**
+     * Static methods on the listed extensions are dispatched through extendableCallStatic().
+     */
+    public $implement = ['Winter\\Storm\\Tests\\Foundation\\WorkerStateStaticExtension'];
+
+    public static function __callStatic($name, $params)
+    {
+        return self::extendableCallStatic($name, $params);
+    }
+}
+
+class WorkerStateStaticExtension
+{
+    use \Winter\Storm\Extension\ExtensionTrait;
+
+    public static function explode()
+    {
+        throw new RuntimeException('static extension exploded');
+    }
+}

--- a/tests/Foundation/WorkerStateTest.php
+++ b/tests/Foundation/WorkerStateTest.php
@@ -26,6 +26,11 @@ class WorkerStateTest extends \Winter\Storm\Tests\TestCase
         $prop->setValue($target, $value);
     }
 
+    protected function callProtected(object $target, string $method, ...$args)
+    {
+        return (new \ReflectionMethod($target, $method))->invoke($target, ...$args);
+    }
+
     protected function getProtected(object $target, string $property)
     {
         $prop = (new ReflectionObject($target))->getProperty($property);
@@ -59,7 +64,25 @@ class WorkerStateTest extends \Winter\Storm\Tests\TestCase
         $this->assertNull($this->getProtected($manager, 'impersonator'), 'impersonation must not persist');
         $this->assertSame([], $this->getProtected($manager, 'throttle'));
         $this->assertFalse($this->getProtected($manager, 'viaRemember'));
-        $this->assertNotSame('203.0.113.9', $manager->ipAddress);
+
+        /*
+         * The address must be left UNRESOLVED, not recaptured. The reset runs at the operation
+         * boundary, before the trusted-proxy middleware has run, so an eager Request::ip() there
+         * records the proxy — or the previous operation's request. resolveIpAddress() derives it
+         * on first use instead, mid-request, once the proxy chain is trusted.
+         */
+        $this->assertNull(
+            $manager->ipAddress,
+            'the reset must leave the IP unresolved rather than sampling the request too early'
+        );
+
+        $resolved = $this->callProtected($manager, 'resolveIpAddress');
+        $this->assertNotSame('203.0.113.9', $resolved, 'the previous operation\'s address must not survive');
+        $this->assertSame(
+            $resolved,
+            $manager->ipAddress,
+            'first use must memoise the derived address for the rest of the operation'
+        );
     }
 
     /**

--- a/tests/Foundation/WorkerStateTest.php
+++ b/tests/Foundation/WorkerStateTest.php
@@ -26,11 +26,6 @@ class WorkerStateTest extends \Winter\Storm\Tests\TestCase
         $prop->setValue($target, $value);
     }
 
-    protected function callProtected(object $target, string $method, ...$args)
-    {
-        return (new \ReflectionMethod($target, $method))->invoke($target, ...$args);
-    }
-
     protected function getProtected(object $target, string $property)
     {
         $prop = (new ReflectionObject($target))->getProperty($property);
@@ -68,7 +63,7 @@ class WorkerStateTest extends \Winter\Storm\Tests\TestCase
         /*
          * The address must be left UNRESOLVED, not recaptured. The reset runs at the operation
          * boundary, before the trusted-proxy middleware has run, so an eager Request::ip() there
-         * records the proxy — or the previous operation's request. resolveIpAddress() derives it
+         * records the proxy — or the previous operation's request. getIpAddress() derives it
          * on first use instead, mid-request, once the proxy chain is trusted.
          */
         $this->assertNull(
@@ -76,12 +71,12 @@ class WorkerStateTest extends \Winter\Storm\Tests\TestCase
             'the reset must leave the IP unresolved rather than sampling the request too early'
         );
 
-        $resolved = $this->callProtected($manager, 'resolveIpAddress');
+        $resolved = $manager->getIpAddress();
         $this->assertNotSame('203.0.113.9', $resolved, 'the previous operation\'s address must not survive');
         $this->assertSame(
             $resolved,
             $manager->ipAddress,
-            'first use must memoise the derived address for the rest of the operation'
+            'first use must memoize the derived address for the rest of the operation'
         );
     }
 

--- a/tests/Foundation/WorkerStateTest.php
+++ b/tests/Foundation/WorkerStateTest.php
@@ -11,11 +11,8 @@ use Winter\Storm\Exception\ErrorHandler;
 use Winter\Storm\Halcyon\MemoryCacheManager;
 
 /**
- * State that a single operation produces must not survive into the next one.
- *
- * Under PHP-FPM each request gets a fresh process, so these are all harmless. Under a persistent
- * application server the same objects and static properties serve every request, and anything
- * derived from one request stays visible to the next.
+ * Request state must not survive into the next request when the process is reused, as it is
+ * under a persistent application server.
  */
 class WorkerStateTest extends \Winter\Storm\Tests\TestCase
 {
@@ -60,12 +57,8 @@ class WorkerStateTest extends \Winter\Storm\Tests\TestCase
         $this->assertSame([], $this->getProtected($manager, 'throttle'));
         $this->assertFalse($this->getProtected($manager, 'viaRemember'));
 
-        /*
-         * The address must be left UNRESOLVED, not recaptured. The reset runs at the operation
-         * boundary, before the trusted-proxy middleware has run, so an eager Request::ip() there
-         * records the proxy — or the previous operation's request. getIpAddress() derives it
-         * on first use instead, mid-request, once the proxy chain is trusted.
-         */
+        // Recapturing here would run before the trusted-proxy middleware, so the reset leaves
+        // the address unresolved and getIpAddress() derives it on first use.
         $this->assertNull(
             $manager->ipAddress,
             'the reset must leave the IP unresolved rather than sampling the request too early'
@@ -110,8 +103,8 @@ class WorkerStateTest extends \Winter\Storm\Tests\TestCase
     }
 
     /**
-     * once() disables session persistence for a single authentication attempt. A throw used to
-     * leave it disabled for every later caller in the process.
+     * once() disables session persistence for a single attempt and must re-enable it even when
+     * authentication throws.
      */
     public function testOnceRestoresSessionUseWhenAuthenticationThrows()
     {
@@ -188,8 +181,8 @@ class WorkerStateTest extends \Winter\Storm\Tests\TestCase
     //
 
     /**
-     * The called class is stored statically while a static extension method runs, so a throw used
-     * to leave the previous caller's class name visible to every later static call.
+     * extendableCallStatic() stores the called class in a static while it runs, and must restore
+     * it when the extension method throws.
      */
     public function testStaticCalledClassIsClearedWhenAnExtensionThrows()
     {
@@ -215,8 +208,8 @@ class WorkerStateTest extends \Winter\Storm\Tests\TestCase
     //
 
     /**
-     * runningInConsole() only reports the SAPI, so an application server that boots from the CLI
-     * and then serves HTTP would otherwise have the request cache silently disabled.
+     * The request cache is disabled for console runs, but a worker serving HTTP is not a console
+     * run even when the process looks like one.
      */
     public function testRequestCacheIsEnabledForAnApplicationServerDespiteTheConsoleSapi()
     {
@@ -248,8 +241,7 @@ class WorkerStateTest extends \Winter\Storm\Tests\TestCase
 }
 
 /**
- * An auth manager whose authentication always fails, standing in for invalid credentials or a
- * failure inside a user model event.
+ * Fails every authentication attempt.
  */
 class WorkerStateThrowingAuthManager extends AuthManager
 {
@@ -263,9 +255,6 @@ class WorkerStateExtendableHost
 {
     use \Winter\Storm\Extension\ExtendableTrait;
 
-    /**
-     * Static methods on the listed extensions are dispatched through extendableCallStatic().
-     */
     public $implement = ['Winter\\Storm\\Tests\\Foundation\\WorkerStateStaticExtension'];
 
     public static function __callStatic($name, $params)


### PR DESCRIPTION
## Summary

Working toward Octane support. Required by wintercms/winter#1511.

The Octane integration itself lives in a first-party plugin, [Winter.Octane](https://github.com/austinderrick/Winter.Octane). The plugin registers Octane's service provider, clears request state at the start of every operation, and carries the worker test suite. This PR contains the Storm changes any integration of that kind needs: services that can discard request state, a way to detect a worker, and an event dispatcher that fires the listeners Octane relies on.

Under PHP-FPM every request gets a fresh process, so state left on a long-lived object never hurts anyone. Under Laravel Octane the same process serves many requests. Anything derived from one request stays visible to the next, and some of it belongs to a different user. Each change below fixes a place where Storm assumes the process is about to die.

Two of the changes also affect PHP-FPM behavior and deserve a closer look: the dispatcher fix and the throttle address fix. Both are called out below. Everything else only runs when an application server calls it.

## Event dispatch

`Winter\Storm\Events\Dispatcher` only fired listeners registered against an event's own class name, never against the interfaces the event implements. Laravel dispatches several of its events by interface, and Octane relies on that: `RequestTerminated` carries the `OperationTerminated` interface, and Octane registers its cleanup against the interface rather than the class. With Winter's dispatcher in place, that cleanup never ran, and nothing errored to show it. The dispatcher now also fires listeners bound to the interfaces an event carries.

`tests/Events/InterfaceListenerTest.php` covers this.

## Application server detection

Several boot-time gates in Winter ask whether the process is serving the back end or running in the console, and neither question identifies a worker. Octane's worker entrypoints set `APP_RUNNING_IN_CONSOLE` to false before the application is created, so `runningInConsole()` answers false inside a worker, but that only separates a worker from an artisan command, not from an ordinary PHP-FPM request.

`Application::runningInApplicationServer()` reports whether a request-serving worker is active. It tests whether `Laravel\Octane\Contracts\Client` is bound, which Octane binds in workers and nowhere else. Installing the package does not bind it, so an ordinary artisan command still answers false.

`tests/Foundation/ApplicationServerDetectionTest.php` covers this.

## Worker state reset

A group of Storm services cache values for the life of one request. Each one now exposes a way to discard that state, and `Winter\Storm\Contracts\ResetsWorkerState` names the contract so Winter can find them.

The services and what they were holding:

* `Auth\Manager` kept the resolved user and the impersonation stack. Left in place, one visitor's session could answer for the next.
* `Halcyon\MemoryCacheManager` and `Halcyon\Model` kept parsed template records that outlived the request that loaded them.
* `Exception\ErrorHandler` kept custom handler masks, so a handler registered by one request stayed registered for later ones.
* `Extension\ExtendableTrait` kept per-request extension bindings.

`Auth\Manager` also no longer captures the client IP address when it is constructed. Construction, and under a worker the operation boundary, can both happen before the trusted-proxy middleware has run, and an address captured that early is the load balancer's rather than the client's. `getIpAddress()` now derives the address the first time something needs it, which under throttling happens mid-request, after the proxy chain is trusted. In console contexts `Request::ip()` is null, and the null is kept rather than replaced with a placeholder, because throttle lookups treat a null address as "match on the user alone" and a placeholder would hide existing ban records. This is the second change that applies under PHP-FPM as well.

The contract asks two things of an implementation. It must be safe to run more than once for a single operation, including after one that threw partway through. And it must leave boot-time registrations alone: aliases and event listeners are built once per worker, and throwing them away leaves the worker degraded for good. That second rule caused me more trouble than the first.

`tests/Foundation/WorkerStateTest.php` covers this.

## Console bootstrap

`RegisterWinter` forced the root URL from config whenever the application reported a console context. A worker boots from a console context, so the override could apply to worker-served traffic and overwrite the URL derived from the real request, pointing generated links at the configured host rather than the one the visitor used. The bootstrapper now applies the override only when no request is bound, which is the case it was written for.

`tests/Foundation/Bootstrap/RegisterWinterTest.php` covers this.

## Documentation

`flushRequestCache` and `flushDuplicateCache` sound alike and do different jobs. The docblocks now say which is which, since picking the wrong one during this work was easy to do.

## Testing

New test files:

| File | Covers |
| --- | --- |
| `tests/Events/InterfaceListenerTest.php` | Interface-registered listeners fire |
| `tests/Foundation/ApplicationServerDetectionTest.php` | Detection is true only in a worker |
| `tests/Foundation/WorkerStateTest.php` | Each service clears what it holds |
| `tests/Foundation/Bootstrap/RegisterWinterTest.php` | Root URL override respects a bound request |
