### PR TITLE
Reset the force-deleting flag when a force delete throws

### DIFF
--- a/src/Halcyon/Datasource/Datasource.php
+++ b/src/Halcyon/Datasource/Datasource.php
@@ -59,11 +59,13 @@ abstract class Datasource implements DatasourceInterface
     {
         $this->forceDeleting = true;
 
-        $success = $this->delete($dirName, $fileName, $extension);
-
-        $this->forceDeleting = false;
-
-        return $success;
+        try {
+            return $this->delete($dirName, $fileName, $extension);
+        } finally {
+            // A delete that throws must not leave the datasource in force-deleting mode,
+            // or every later ordinary delete on this instance becomes a hard delete.
+            $this->forceDeleting = false;
+        }
     }
 
     /**

--- a/tests/Halcyon/DatasourceForceDeleteTest.php
+++ b/tests/Halcyon/DatasourceForceDeleteTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Winter\Storm\Filesystem\Filesystem;
+use Winter\Storm\Halcyon\Datasource\Datasource;
+use Winter\Storm\Halcyon\Datasource\FileDatasource;
+
+class DatasourceForceDeleteTest extends \Winter\Storm\Tests\TestCase
+{
+    protected function getForceDeleting(Datasource $datasource): bool
+    {
+        return (new ReflectionProperty(Datasource::class, 'forceDeleting'))->getValue($datasource);
+    }
+
+    public function testForceDeleteResetsTheFlagWhenDeleteThrows()
+    {
+        $datasource = new class ('/tmp', new Filesystem) extends FileDatasource
+        {
+            public function delete(string $dirName, string $fileName, string $extension): bool
+            {
+                throw new RuntimeException('delete failed');
+            }
+        };
+
+        $caught = null;
+
+        try {
+            $datasource->forceDelete('pages', 'index', 'htm');
+        }
+        catch (RuntimeException $ex) {
+            $caught = $ex;
+        }
+
+        // Asserted outside the catch: PHPUnit's own assertion failures extend RuntimeException,
+        // so a fail() inside the try would be swallowed by the catch above.
+        $this->assertInstanceOf(RuntimeException::class, $caught, 'forceDelete() must propagate the failure');
+        $this->assertSame('delete failed', $caught->getMessage());
+
+        $this->assertFalse(
+            $this->getForceDeleting($datasource),
+            'A failed force delete must not leave the datasource in force-deleting mode, or every '
+            . 'later ordinary delete on this instance becomes a hard delete.'
+        );
+    }
+
+    public function testForceDeleteReturnsTheDeleteResultAndResetsTheFlag()
+    {
+        $datasource = new class ('/tmp', new Filesystem) extends FileDatasource
+        {
+            /**
+             * @var bool The flag value observed while delete() ran.
+             */
+            public $flagDuringDelete = false;
+
+            public function delete(string $dirName, string $fileName, string $extension): bool
+            {
+                $this->flagDuringDelete = $this->forceDeleting;
+
+                return true;
+            }
+        };
+
+        $this->assertTrue($datasource->forceDelete('pages', 'index', 'htm'));
+        $this->assertTrue($datasource->flagDuringDelete, 'delete() should run in force-deleting mode');
+        $this->assertFalse($this->getForceDeleting($datasource));
+    }
+}


### PR DESCRIPTION
If `delete()` throws inside `forceDelete()`, the flag never resets and the datasource is stuck in force-delete mode. Every ordinary delete after that runs as a hard delete.

The fix wraps the call in try/finally so the flag always resets and the exception still reaches the caller. Two tests cover the throwing path and the happy path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved force deletion cleanup so its internal state is reset even when deletion fails.
  - Deletion errors continue to be reported correctly, while successful deletions retain their existing results.

- **Tests**
  - Added coverage for successful and failed force-deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->